### PR TITLE
fix: OL Result layout bugs + Sending screen Shazam-style redesign

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2706,6 +2706,8 @@ window.openObserverLink = olOpen;
 function olClose(){
   stopOlHeroCanvas();
   olParticles.destroy();
+  olSendingParticles.destroy();
+  olResetSendingView();
   const screen = document.getElementById('observer-link-screen');
   if(screen){ screen.style.display = 'none'; screen.classList.remove('ol-open'); }
   document.body.style.overflow = '';
@@ -2887,8 +2889,90 @@ function olCreatePickerItem(song){
   return el;
 }
 
+// === SENDING PARTICLES ===
+var olSendingParticles = {
+  canvas:null, ctx:null, raf:null, dots:[],
+  init:function(canvasEl){
+    this.canvas = canvasEl;
+    this.ctx = canvasEl.getContext('2d');
+    this.dots = [];
+    this.resize();
+    this._onResize = this.resize.bind(this);
+    window.addEventListener('resize', this._onResize);
+    var rect = canvasEl.parentElement.getBoundingClientRect();
+    for(var i=0;i<40;i++){
+      this.dots.push({
+        x:Math.random()*rect.width,
+        y:Math.random()*rect.height,
+        vx:(Math.random()-.5)*.3,
+        vy:-(.2+Math.random()*.4),
+        r:Math.random()*1.5+.5,
+        a:Math.random()*.15+.03,
+        life:Math.random()*Math.PI*2
+      });
+    }
+    if(!window.matchMedia('(prefers-reduced-motion: reduce)').matches) this.animate();
+  },
+  resize:function(){
+    if(!this.canvas) return;
+    var d = devicePixelRatio||1;
+    var r = this.canvas.parentElement.getBoundingClientRect();
+    this.canvas.width = r.width*d; this.canvas.height = r.height*d;
+    this.canvas.style.width = r.width+'px'; this.canvas.style.height = r.height+'px';
+    this.ctx.scale(d,d);
+  },
+  animate:function(){
+    var self = this;
+    var ctx = this.ctx;
+    var r = this.canvas.parentElement.getBoundingClientRect();
+    ctx.clearRect(0,0,r.width,r.height);
+    this.dots.forEach(function(d){
+      d.x += d.vx; d.y += d.vy; d.life += .02;
+      if(d.y < -10){ d.y = r.height+10; d.x = Math.random()*r.width; }
+      if(d.x < -10) d.x = r.width+10;
+      if(d.x > r.width+10) d.x = -10;
+      var pulse = (Math.sin(d.life)+1)/2;
+      ctx.beginPath();
+      ctx.arc(d.x, d.y, d.r, 0, Math.PI*2);
+      ctx.fillStyle = 'rgba(108,92,231,'+(d.a+pulse*.05)+')';
+      ctx.fill();
+    });
+    this.raf = requestAnimationFrame(function(){ self.animate(); });
+  },
+  destroy:function(){
+    if(this.raf) cancelAnimationFrame(this.raf);
+    this.raf = null; this.dots = [];
+    if(this._onResize) window.removeEventListener('resize', this._onResize);
+  }
+};
+
 // === SEND ===
 let olSending = false;
+
+function olShowSendingCard(song){
+  var card = document.getElementById('olSendingCard');
+  if(!card || !song) return;
+  var vid = ytId(song.url || '');
+  var thumb = vid ? 'https://img.youtube.com/vi/'+vid+'/mqdefault.jpg' : '';
+  var memberDisplay = olGetMemberDisplay(song.member);
+  card.innerHTML = '<div class="ol-sending-card-thumb">'+(thumb?'<img src="'+esc(thumb)+'" alt="">':'')+'</div>'
+    + '<div style="overflow:hidden"><div class="ol-sending-card-member">'+esc(memberDisplay)+'</div>'
+    + '<div class="ol-sending-card-title">'+esc(song.title)+'</div></div>';
+  card.classList.add('visible');
+}
+
+function olResetSendingView(){
+  var view = document.getElementById('olSendingScreen');
+  if(view) view.classList.remove('matched');
+  var title = document.getElementById('olSendingTitle');
+  if(title){ title.textContent = 'LINKING OBSERVERS'; title.style.color = ''; }
+  var sub = document.getElementById('olSendingSub');
+  if(sub) sub.textContent = 'Searching for a match...';
+  var card = document.getElementById('olSendingCard');
+  if(card){ card.classList.remove('visible'); card.innerHTML = ''; }
+  olSendingParticles.destroy();
+}
+
 function olSendRecord(){
   if(!olSelectedSong || olSending) return;
   olSending = true;
@@ -2902,10 +2986,12 @@ function olSendRecord(){
     has_message: msg ? 'true' : 'false',
   });
 
+  // Reset and show sending screen
+  olResetSendingView();
   olShowScreen('olSendingScreen');
-  // Reset disc animation — spin first, fly after API response
-  const disc = document.getElementById('olSendingDisc');
-  if(disc){ disc.classList.remove('fly','spinning'); void disc.offsetWidth; disc.classList.add('spinning'); }
+  olShowSendingCard(olSelectedSong);
+  var pCanvas = document.getElementById('ol-sending-particles');
+  if(pCanvas) olSendingParticles.init(pCanvas);
   document.getElementById('olAmbientGlow')?.classList.add('bright');
 
   // API call
@@ -2929,7 +3015,7 @@ function olSendRecord(){
       olShowToast(errMsg);
       olSending = false;
       olUpdateSendBtn();
-      if(disc) disc.classList.remove('spinning');
+      olResetSendingView();
       olShowScreen('olComposeScreen');
       document.getElementById('olAmbientGlow')?.classList.remove('bright');
       return;
@@ -2958,22 +3044,28 @@ function olSendRecord(){
       _gtag('event','ol_match_success',{sent_video_id:String(olSelectedSong.id),received_video_id:data.received?String(data.received.video_id):'',time_ago_seconds:data.received?.time_ago_seconds||0});
     }
 
-    // Transition disc: spin → fly
-    if(disc){ disc.classList.remove('spinning'); void disc.offsetWidth; disc.classList.add('fly'); }
+    // Match transition: converge pulses + green + "LINK ESTABLISHED"
+    var view = document.getElementById('olSendingScreen');
+    var title = document.getElementById('olSendingTitle');
+    var sub = document.getElementById('olSendingSub');
+    if(view) view.classList.add('matched');
+    if(title){ title.textContent = 'LINK ESTABLISHED'; title.style.color = '#22c55e'; }
+    if(sub) sub.textContent = 'A record from another observer';
 
-    // Wait for fly animation (3s), then show result
+    // Fade to result after match animation
     setTimeout(() => {
       olSending = false;
       olUpdateSendBtn();
+      olResetSendingView();
       olShowResult(data);
       document.getElementById('olAmbientGlow')?.classList.remove('bright');
-    }, 2800);
+    }, 1300);
   })
   .catch(() => {
     olShowToast('Network error — please try again');
     olSending = false;
     olUpdateSendBtn();
-    if(disc) disc.classList.remove('spinning');
+    olResetSendingView();
     olShowScreen('olComposeScreen');
     document.getElementById('olAmbientGlow')?.classList.remove('bright');
   });
@@ -3163,6 +3255,9 @@ function olShowResult(data){
     + '<div class="ol-cards-area">' + sentCardHtml + connectorHtml + receivedCardHtml + '</div>'
     + actionsHtml;
 
+  // Clean up sending view before showing result
+  olResetSendingView();
+
   olShowScreen('olResultScreen');
 
   // Init particles
@@ -3236,6 +3331,8 @@ window.olTrackXShare = function() {
 
 window.olResetCompose = function(){
   olParticles.destroy();
+  olSendingParticles.destroy();
+  olResetSendingView();
   olSelectedSong = null;
   olSelectedMoods = [];
   olSending = false;
@@ -3342,20 +3439,29 @@ window.olQuickSend = function(videoId, btnEl, evt){
     if(screen){ screen.style.display = ''; screen.classList.add('ol-open'); }
     document.body.style.overflow = 'hidden';
 
+    // Show Shazam-style sending screen with match transition
+    olResetSendingView();
     olShowScreen('olSendingScreen');
-    var disc = document.getElementById('olSendingDisc');
-    if(disc){ disc.classList.remove('fly','spinning'); void disc.offsetWidth; disc.classList.add('spinning'); }
+    olShowSendingCard(song);
+    var qsCanvas = document.getElementById('ol-sending-particles');
+    if(qsCanvas) olSendingParticles.init(qsCanvas);
     document.getElementById('olAmbientGlow')?.classList.add('bright');
 
-    // Brief spin then fly
+    // Match transition after brief pause
     setTimeout(function(){
-      if(disc){ disc.classList.remove('spinning'); void disc.offsetWidth; disc.classList.add('fly'); }
+      var view = document.getElementById('olSendingScreen');
+      var title = document.getElementById('olSendingTitle');
+      var sub = document.getElementById('olSendingSub');
+      if(view) view.classList.add('matched');
+      if(title){ title.textContent = 'LINK ESTABLISHED'; title.style.color = '#22c55e'; }
+      if(sub) sub.textContent = 'A record from another observer';
       setTimeout(function(){
         olSending = false;
         olUpdateSendBtn();
+        olResetSendingView();
         olShowResult(data);
         document.getElementById('olAmbientGlow')?.classList.remove('bright');
-      }, 2800);
+      }, 1300);
     }, 800);
   })
   .catch(function(){

--- a/public/index.html
+++ b/public/index.html
@@ -575,24 +575,33 @@
       </div>
     </div>
 
-    <!-- SENDING -->
-    <div class="ol-screen ol-sending-screen ol-hidden" id="olSendingScreen">
-      <div class="ol-sending-content">
-        <div class="ol-sending-disc-wrap">
-          <div class="ol-sending-disc" id="olSendingDisc">
-            <svg viewBox="0 0 120 120">
-              <circle cx="60" cy="60" r="56" fill="rgba(20,20,30,.9)" stroke="rgba(196,181,253,.2)" stroke-width="1"/>
-              <circle cx="60" cy="60" r="45" fill="none" stroke="rgba(196,181,253,.05)" stroke-width=".5"/>
-              <circle cx="60" cy="60" r="36" fill="none" stroke="rgba(196,181,253,.04)" stroke-width=".5"/>
-              <circle cx="60" cy="60" r="27" fill="none" stroke="rgba(196,181,253,.04)" stroke-width=".5"/>
-              <circle cx="60" cy="60" r="16" fill="rgba(196,181,253,.12)"/>
-              <circle cx="60" cy="60" r="3.5" fill="rgba(196,181,253,.3)"/>
+    <!-- SENDING (Shazam-style pulse) -->
+    <div class="ol-screen ol-sending-view ol-hidden" id="olSendingScreen">
+      <canvas id="ol-sending-particles"></canvas>
+      <div class="ol-sending-pulse-container">
+        <div class="ol-pulse-ring"></div>
+        <div class="ol-pulse-ring"></div>
+        <div class="ol-pulse-ring"></div>
+        <div class="ol-pulse-ring"></div>
+        <div class="ol-center-disc">
+          <div class="ol-lp-icon">
+            <svg viewBox="0 0 52 52" fill="none">
+              <circle cx="26" cy="26" r="25" stroke="rgba(167,139,250,.5)" stroke-width=".8"/>
+              <circle cx="26" cy="26" r="20" stroke="rgba(167,139,250,.15)" stroke-width=".5"/>
+              <circle cx="26" cy="26" r="15" stroke="rgba(167,139,250,.1)" stroke-width=".5"/>
+              <circle cx="26" cy="26" r="10" stroke="rgba(167,139,250,.08)" stroke-width=".5"/>
+              <circle cx="26" cy="26" r="7" fill="rgba(108,92,231,.4)"/>
+              <circle cx="26" cy="26" r="4" fill="rgba(108,92,231,.7)"/>
+              <circle cx="26" cy="26" r="1.5" fill="rgba(232,236,248,.4)"/>
             </svg>
           </div>
         </div>
-        <div class="ol-sending-text">Delivering your record...</div>
-        <div class="ol-sending-sub">LINKING OBSERVERS</div>
       </div>
+      <div class="ol-sending-text-area">
+        <div class="ol-sending-title" id="olSendingTitle">LINKING OBSERVERS</div>
+        <div class="ol-sending-sub" id="olSendingSub">Searching for a match...</div>
+      </div>
+      <div class="ol-sending-card" id="olSendingCard"></div>
     </div>
 
     <!-- RESULT -->

--- a/public/style.css
+++ b/public/style.css
@@ -754,8 +754,8 @@ body.light .shelf-empty { color: var(--dim); }
   #observer-link-screen.ol-open{display:flex;align-items:center;justify-content:center;background:rgba(7,9,14,.92);backdrop-filter:blur(10px)}
   .ol-app{max-width:430px;height:auto;max-height:90vh;border-radius:16px;border:1px solid rgba(255,255,255,.06);box-shadow:0 20px 60px rgba(0,0,0,.6);overflow-y:auto}
 }
-.ol-screen{position:absolute;inset:0;display:flex;flex-direction:column;transition:transform .6s cubic-bezier(.4,0,.2,1),opacity .5s ease;will-change:transform,opacity;background:#07090e}
-.ol-hidden{pointer-events:none;opacity:0;transform:translateY(30px)}
+.ol-screen{position:absolute;inset:0;display:flex;flex-direction:column;transition:transform .6s cubic-bezier(.4,0,.2,1),opacity .5s ease,visibility .5s ease;will-change:transform,opacity;background:#07090e}
+.ol-hidden{pointer-events:none;opacity:0;transform:translateY(30px);visibility:hidden}
 @media(min-width:701px){.ol-screen{position:relative;inset:auto}.ol-hidden{display:none}}
 .ol-ambient-glow{position:absolute;top:20%;left:50%;width:350px;height:350px;transform:translateX(-50%);border-radius:50%;filter:blur(120px);opacity:.10;background:#c4b5fd;pointer-events:none;z-index:0;transition:opacity 1.2s ease}
 .ol-ambient-glow.bright{opacity:.22}
@@ -800,18 +800,36 @@ body.light .shelf-empty { color: var(--dim); }
 /* ── Observer-Link icon: oscilloscope border glow ── */
 .tt-lp[data-m="ol"] .tt-lp-face{box-shadow:0 0 0px 1.5px rgba(108,92,231,.45),0 0 10px 2px rgba(108,92,231,.18),0 0 24px 6px rgba(80,60,200,.10),0 0 55px 14px rgba(60,40,180,.06);animation:ol-ring-pulse 2.8s ease-in-out infinite}
 @keyframes ol-ring-pulse{0%,100%{box-shadow:0 0 0px 1.5px rgba(108,92,231,.45),0 0 10px 2px rgba(108,92,231,.18),0 0 24px 6px rgba(80,60,200,.10),0 0 55px 14px rgba(60,40,180,.06)}50%{box-shadow:0 0 0px 2.5px rgba(150,130,255,.90),0 0 20px 6px rgba(108,92,231,.48),0 0 44px 12px rgba(80,60,200,.28),0 0 90px 26px rgba(60,40,180,.16)}}
-/* Sending */
-.ol-sending-screen{z-index:30;display:flex;align-items:center;justify-content:center}
-.ol-sending-content{text-align:center}
-.ol-sending-disc-wrap{width:120px;height:120px;margin:0 auto 28px}
-.ol-sending-disc{width:100%;height:100%}
-@keyframes olDiscSpin{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
-.ol-sending-disc.spinning{animation:olDiscSpin .8s linear infinite}
-.ol-sending-disc.fly{animation:olDiscFly 3s cubic-bezier(.4,0,.2,1) forwards}
-@keyframes olDiscFly{0%{transform:scale(1) rotate(0deg);opacity:1}50%{transform:scale(.85) rotate(360deg);opacity:.9}80%{transform:scale(.4) rotate(600deg) translateY(-50px);opacity:.4}100%{transform:scale(.15) rotate(720deg) translateY(-100px);opacity:0}}
-.ol-sending-text{font-family:'Shippori Mincho',serif;font-size:15px;color:rgba(232,236,248,.45);animation:olFadeIn 3s ease forwards}
-.ol-sending-sub{font-family:'Barlow Condensed',sans-serif;font-size:12px;letter-spacing:2px;color:rgba(232,236,248,.22);margin-top:10px;animation:olFadeIn 3s ease .5s both}
-@keyframes olFadeIn{0%,30%{opacity:0}60%{opacity:1}}
+/* Sending — Shazam-style pulse */
+.ol-sending-view{z-index:30;display:flex;flex-direction:column;align-items:center;justify-content:center;overflow:hidden}
+#ol-sending-particles{position:absolute;inset:0;z-index:0;pointer-events:none}
+.ol-sending-pulse-container{position:relative;width:280px;height:280px;display:flex;align-items:center;justify-content:center;z-index:1}
+.ol-pulse-ring{position:absolute;width:80px;height:80px;border-radius:50%;border:1px solid var(--ol-accent,#6c5ce7);opacity:0;animation:ol-pulse-out 2.8s cubic-bezier(.25,.46,.45,.94) infinite}
+.ol-pulse-ring:nth-child(1){animation-delay:0s}
+.ol-pulse-ring:nth-child(2){animation-delay:.7s}
+.ol-pulse-ring:nth-child(3){animation-delay:1.4s}
+.ol-pulse-ring:nth-child(4){animation-delay:2.1s}
+@keyframes ol-pulse-out{0%{transform:scale(1);opacity:.6;border-width:2px}100%{transform:scale(3.5);opacity:0;border-width:.5px}}
+.ol-center-disc{position:relative;z-index:2;width:90px;height:90px;border-radius:50%;background:rgba(108,92,231,.12);border:1.5px solid rgba(108,92,231,.4);display:flex;align-items:center;justify-content:center;animation:ol-disc-breathe 2s ease-in-out infinite}
+@keyframes ol-disc-breathe{0%,100%{transform:scale(1);border-color:rgba(108,92,231,.4)}50%{transform:scale(1.05);border-color:rgba(108,92,231,.6)}}
+.ol-lp-icon{width:52px;height:52px}
+.ol-lp-icon svg{width:100%;height:100%;animation:ol-lp-spin 4s linear infinite}
+@keyframes ol-lp-spin{from{transform:rotate(0)}to{transform:rotate(360deg)}}
+.ol-sending-text-area{margin-top:40px;text-align:center;z-index:1}
+.ol-sending-title{font-family:'Cinzel',serif;font-size:13px;letter-spacing:4px;color:rgba(232,236,248,.8);animation:ol-text-breathe 2.8s ease-in-out infinite}
+@keyframes ol-text-breathe{0%,100%{opacity:.5}50%{opacity:1}}
+.ol-sending-sub{font-family:'Barlow Condensed',sans-serif;font-size:11px;letter-spacing:2px;color:rgba(232,236,248,.3);margin-top:8px}
+.ol-sending-card{margin-top:36px;padding:10px 20px;border-radius:12px;background:rgba(108,92,231,.06);border:1px solid rgba(108,92,231,.12);display:none;align-items:center;gap:12px;max-width:300px;z-index:1}
+.ol-sending-card.visible{display:flex}
+.ol-sending-card-thumb{width:40px;height:40px;border-radius:6px;background:rgba(255,255,255,.05);flex-shrink:0;overflow:hidden}
+.ol-sending-card-thumb img{width:100%;height:100%;object-fit:cover}
+.ol-sending-card-member{font-family:'Barlow Condensed',sans-serif;font-size:10px;letter-spacing:1.5px;color:#a78bfa;font-weight:400}
+.ol-sending-card-title{font-family:'Barlow Condensed',sans-serif;font-size:13px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:#e8ecf8}
+/* Sending — matched transition */
+.ol-sending-view.matched .ol-pulse-ring{animation:ol-pulse-converge .8s ease-in forwards}
+@keyframes ol-pulse-converge{0%{transform:scale(2);opacity:.3}100%{transform:scale(1);opacity:.7;border-color:#22c55e}}
+.ol-sending-view.matched .ol-center-disc{animation:none;border-color:rgba(34,197,94,.6);background:rgba(34,197,94,.12);transition:all .5s ease}
+.ol-sending-view.matched .ol-sending-title{animation:none;opacity:1}
 /* Result */
 .ol-result-body{flex:1;padding:0;overflow-y:auto;-webkit-overflow-scrolling:touch;position:relative;z-index:10;display:flex;flex-direction:column;align-items:center}
 #olResultParticles{position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:0}
@@ -913,6 +931,7 @@ body.light .shelf-empty { color: var(--dim); }
 .ol-toast{position:fixed;bottom:30px;left:50%;transform:translateX(-50%) translateY(80px);background:#111627;border:1px solid rgba(255,255,255,.10);border-radius:12px;padding:10px 20px;font-size:12px;color:rgba(232,236,248,.45);z-index:10100;opacity:0;transition:all .4s cubic-bezier(.4,0,.2,1);white-space:nowrap}
 .ol-toast.show{opacity:1;transform:translateX(-50%) translateY(0)}
 #observer-link-screen ::-webkit-scrollbar{width:0;height:0}
+@media(prefers-reduced-motion:reduce){.ol-pulse-ring,.ol-center-disc,.ol-sending-title,.ol-lp-icon svg{animation:none!important}}
 
 /* === RECEIVED RECORDS shelf === */
 #my-shelf-overlay .shelf-section-header.received{


### PR DESCRIPTION
## Summary

- **Fix**: OL Result画面の上部空白 + LP盤残留バグを修正
- **Redesign**: Sending画面をShazam風パルスアニメーションに全面置き換え

## Pre-implementation Investigation (Section 0)

### 0-1. Layout bug root causes

**Top whitespace**: On mobile, `.ol-hidden` only set `opacity:0;pointer-events:none;transform:translateY(30px)` — hidden screens remained in the rendering pipeline. The Sending screen (`z-index:30`) sitting above the Result screen with `opacity:0` caused compositing artifacts and layout shifts.

**LP disc residue**: The `.ol-sending-disc.fly` animation ended at `opacity:0` but the element's `.fly` class was never removed after transitioning to Result. On mobile (where `.ol-hidden` ≠ `display:none`), this left a phantom disc in the DOM between card transitions.

### 0-2. Sending screen components identified

| Component | Location | Selector |
|---|---|---|
| HTML structure | `index.html:579-596` | `#olSendingScreen > .ol-sending-content` |
| Disc SVG | `index.html:582-591` | `#olSendingDisc` |
| CSS animations | `style.css:803-813` | `olDiscSpin`, `olDiscFly`, `olFadeIn` |
| JS flow | `app.js:2892-2980` | `olSendRecord()` → spin → API → fly → 2.8s → result |
| Quick Send flow | `app.js:3439-3453` | Same disc spin/fly pattern |

## Bug Fixes

| Fix | What changed |
|---|---|
| `visibility:hidden` on `.ol-hidden` | Hidden screens are now fully invisible to rendering, preventing compositing artifacts |
| `visibility` added to `.ol-screen` transition | Smooth fade-in/out still works (visibility stays visible during opacity transition, then snaps to hidden) |
| `olResetSendingView()` in `olShowResult` | Sending view state (matched class, title, card, particles) is cleaned up before Result screen appears |

## Sending Screen Redesign

Replaced old disc-spin-fly animation with Shazam-inspired "listening" UI:

| Element | Implementation |
|---|---|
| 4 concentric pulse rings | CSS `ol-pulse-out` animation, staggered 0.7s delays |
| Center LP disc | SVG grooves + `ol-disc-breathe` scale animation |
| LP spin | `ol-lp-spin` 4s infinite rotation |
| Floating particles | Canvas (`#ol-sending-particles`), 40 dots drifting upward |
| Song info card | Thumbnail + member + title below the pulse area |
| Match transition | `.matched` class → pulses converge (`ol-pulse-converge`), disc turns green, title → "LINK ESTABLISHED" |
| Timing | Pulse (searching) → match animation (0.8s) → hold (0.5s) → fade to Result |

Both `olSendRecord()` and Quick Send use the same new sending screen.

## Files Changed

| File | Lines | Changes |
|---|---|---|
| `public/index.html` | +21/-16 | Replace sending screen HTML (pulse container + disc + card + canvas) |
| `public/style.css` | +34/-13 | Replace sending CSS + add `visibility:hidden` fix + reduced-motion |
| `public/app.js` | +121/-13 | `olSendingParticles` system + `olShowSendingCard` + `olResetSendingView` + match transition logic |

**No new files.** All changes in existing 3 files.

## Test Plan

### Bug fixes
- [ ] Result画面で上部に不要な空白がないこと
- [ ] Result画面でLP盤やcanvasが残留していないこと
- [ ] YOUR RECORD + RECEIVED RECORD カードが正常表示
- [ ] フォールバック(RECOMMENDED)時も正常レイアウト

### Sending screen
- [ ] SEND RECORD後、Shazam風パルスが表示
- [ ] 中央LP盤が回転
- [ ] 4つのパルスリングが広がる
- [ ] 送信曲のサムネ+メンバー+タイトルが下部カードに表示
- [ ] 「LINKING OBSERVERS」テキストが呼吸アニメーション
- [ ] パーティクルが背景で漂う
- [ ] API応答後: パルス収束+緑化+「LINK ESTABLISHED」→Result画面フェードイン
- [ ] モバイル(700px以下)で正常表示

### Regression
- [ ] OL Compose画面が正常動作(曲選択・ムード・メッセージ)
- [ ] Quick Sendからも新Sending画面が表示されること
- [ ] OL Result画面のShare機能が動作
- [ ] メインサイト(/)が正常動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)