### PR TITLE
fix: Admin DB query defensive array check

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -82,7 +82,12 @@ Admin.DB = (() => {
       }
       return 0;
     }
-    return res.json();
+    var data = await res.json();
+    if (!Array.isArray(data)) {
+      console.error('[Admin.DB] query error:', table, data);
+      return [];
+    }
+    return data;
   }
 
   async function rpc(fnName, params) {


### PR DESCRIPTION
## Summary

- Supabase REST APIがエラー時にオブジェクト(`{message:...}`)を返すと、`dupRows.forEach is not a function` 等のエラーが全3タブで発生していた
- `Admin.DB.query()` の戻り値に `Array.isArray` チェックを追加し、非配列レスポンス時は `[]` を返してコンソールにエラーログを出力

## Changed

| File | Change |
|---|---|
| `public/admin.js` | `query()` に `Array.isArray(data)` ガード追加 (+6/-1) |

## Root Cause

`res.json()` をそのまま返していたため、Supabaseが認証エラーやクエリエラーで `{"message":"...","hint":"..."}` を返すとcallerの `.forEach()` で TypeError になっていた。

## Test Plan

- [ ] 正常認証時: 3タブ全て正常にデータ表示
- [ ] DevTools Console に `[Admin.DB] query error:` が出ないこと（正常時）
- [ ] 無効なトークンでログイン試行時: エラーがコンソールに出力され、UIがクラッシュしないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)