### PR TITLE
fix: Admin query defense — remove head/content-range, harden all queries

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -69,22 +69,13 @@ Admin.DB = (() => {
     if (order) url += '&order=' + order;
     if (limit) url += '&limit=' + limit;
     var h = headers();
-    if (p.head) {
-      h['Prefer'] = 'count=exact';
-      h['Range'] = '0-0';
-    }
     var res = await fetch(url, { headers: h });
-    if (p.head) {
-      var range = res.headers.get('content-range');
-      if (range) {
-        var parts = range.split('/');
-        return parseInt(parts[1], 10) || 0;
-      }
-      return 0;
+    if (!res.ok) {
+      console.error('[Admin.DB] HTTP ' + res.status + ' for ' + table + ' (' + url + ')');
     }
     var data = await res.json();
     if (!Array.isArray(data)) {
-      console.error('[Admin.DB] query error:', table, data);
+      console.error('[Admin.DB] non-array response:', table, url, data);
       return [];
     }
     return data;
@@ -215,13 +206,16 @@ Admin.Tabs.register('songs', {
   async render(el) {
     var U = Admin.UI;
     try {
-      var [totalCount, unlinkedCount, dupRows, albumCount, allVideos] = await Promise.all([
-        Admin.DB.query('videos', { select: 'id', head: true }),
-        Admin.DB.query('videos', { select: 'id', filter: 'album_id=is.null', head: true }),
+      var [totalRows, unlinkedRows, dupRows, albumRows, allVideos] = await Promise.all([
+        Admin.DB.query('videos', { select: 'id' }),
+        Admin.DB.query('videos', { select: 'id', filter: 'album_id=is.null' }),
         Admin.DB.query('videos', { select: 'url', order: 'url' }),
-        Admin.DB.query('albums', { select: 'id', head: true }),
+        Admin.DB.query('albums', { select: 'id' }),
         Admin.DB.query('videos', { select: 'id,title,member,date,url', order: 'date.desc', limit: '1000' })
       ]);
+      var totalCount = totalRows.length;
+      var unlinkedCount = unlinkedRows.length;
+      var albumCount = albumRows.length;
 
       // Count duplicates
       var urlMap = {};
@@ -391,11 +385,13 @@ Admin.Tabs.register('health', {
   async render(el) {
     var U = Admin.UI;
     try {
-      var [songCount, bottleCount, freshVideos] = await Promise.all([
-        Admin.DB.query('videos', { select: 'id', head: true }),
-        Admin.DB.query('song_bottles', { select: 'id', head: true }),
+      var [songRows, bottleRows, freshVideos] = await Promise.all([
+        Admin.DB.query('videos', { select: 'id' }),
+        Admin.DB.query('song_bottles', { select: 'id' }),
         Admin.DB.query('videos', { select: 'id,title,member,date', order: 'date.desc', limit: '500' })
       ]);
+      var songCount = songRows.length;
+      var bottleCount = bottleRows.length;
 
       // Freshness per solo member
       var freshness = [];


### PR DESCRIPTION
## Summary
- **Remove broken `head: true` code path** from `Admin.DB.query()` — CORS blocks `content-range` header, causing all count queries to return 0
- **Replace with `.length`** on fetched rows for SONGS (totalCount, unlinkedCount, albumCount) and HEALTH (songCount, bottleCount)
- **Enhanced error logging** — logs HTTP status + full URL on non-OK responses, and logs the actual non-array response body for debugging

## Fixes
- `dupRows.forEach is not a function` (SONGS tab)
- `allVideos.forEach is not a function` (OL tab — via Array.isArray defense already in place)
- `freshVideos.forEach is not a function` (HEALTH tab)
- Count metrics (Total songs, Albums, Videos, Bottles) showing 0

## Test plan
- [ ] Login to `/admin` — CRT terminal + boot sequence works
- [ ] SONGS tab: Total songs, Unlinked albums, Albums show correct counts (not 0)
- [ ] SONGS tab: Duplicate URLs and Content freshness render without errors
- [ ] OL tab: Bottle pool, Member breakdown, Hourly chart render
- [ ] HEALTH tab: Videos/Bottles counts show correct numbers
- [ ] Open DevTools Console — no `forEach is not a function` errors
- [ ] Intentionally break Supabase URL — console shows `[Admin.DB] HTTP ...` and `[Admin.DB] non-array response:` logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)