### PR TITLE
fix: OL sending pulse ring + result screen transition

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2943,6 +2943,9 @@ var olSendingParticles = {
   destroy:function(){
     if(this.raf) cancelAnimationFrame(this.raf);
     this.raf = null; this.dots = [];
+    if(this.canvas && this.ctx){
+      this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    }
     if(this._onResize) window.removeEventListener('resize', this._onResize);
   }
 };

--- a/public/style.css
+++ b/public/style.css
@@ -804,7 +804,7 @@ body.light .shelf-empty { color: var(--dim); }
 .ol-sending-view{z-index:30;display:flex;flex-direction:column;align-items:center;justify-content:center}
 #ol-sending-particles{position:absolute;inset:0;z-index:0;pointer-events:none}
 .ol-sending-pulse-container{position:relative;width:280px;height:280px;display:flex;align-items:center;justify-content:center;z-index:1}
-.ol-pulse-ring{position:absolute;width:80px;height:80px;border-radius:50%;border:1px solid var(--ol-accent,#6c5ce7);opacity:0;animation:ol-pulse-out 2.8s cubic-bezier(.25,.46,.45,.94) infinite}
+.ol-pulse-ring{position:absolute;inset:0;margin:auto;width:80px;height:80px;border-radius:50%;border:1px solid var(--ol-accent,#6c5ce7);opacity:0;animation:ol-pulse-out 2.8s cubic-bezier(.25,.46,.45,.94) infinite}
 .ol-pulse-ring:nth-child(1){animation-delay:0s}
 .ol-pulse-ring:nth-child(2){animation-delay:.7s}
 .ol-pulse-ring:nth-child(3){animation-delay:1.4s}
@@ -831,6 +831,7 @@ body.light .shelf-empty { color: var(--dim); }
 .ol-sending-view.matched .ol-center-disc{animation:none;border-color:rgba(34,197,94,.6);background:rgba(34,197,94,.12);transition:all .5s ease}
 .ol-sending-view.matched .ol-sending-title{animation:none;opacity:1}
 /* Result */
+.ol-result{z-index:31}
 .ol-result-body{flex:1;padding:0;overflow-y:auto;-webkit-overflow-scrolling:touch;position:relative;z-index:10;display:flex;flex-direction:column;align-items:center}
 #olResultParticles{position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:0}
 .ol-ambient{position:absolute;top:25%;left:50%;width:400px;height:400px;transform:translate(-50%,-50%);border-radius:50%;background:radial-gradient(circle,rgba(108,92,231,.2) 0%,rgba(93,201,168,.08) 50%,transparent 70%);filter:blur(60px);animation:ol-ambient-breathe 4s ease-in-out infinite;pointer-events:none;z-index:0}


### PR DESCRIPTION
## Summary
- **CRITICAL**: パルスリング (`ol-pulse-ring`) が親コンテナ内で��央配置されておらず、`scale(3.5)` 時に画面全体を覆っていた → `inset:0;margin:auto` で正しく中央配置
- **HIGH**: Sending→Result 遷移時に緑背景が残留 → `.ol-result` に `z-index:31` を追加し、sending (z-index:30) より上に描画
- **MEDIUM**: Sending canvas が destroy 時にクリアされず、遷移中にアーティファクトが残る → `clearRect` を `destroy()` に追加

## 発見された問題一覧

| # | カテゴリ | 重要度 | 問題 | 状態 |
|---|---------|--------|------|------|
| 1 | OL Sending | CRITICAL | パルスリング位置未指定で画面全体覆い | ✅ 修正済 |
| 2 | OL Result | HIGH | 緑背景残留（z-index不整合 + canvas未クリア） | ✅ 修正済 |
| 3 | OL Compose | OK | ヒーローcanvas正常動作確認 | ✅ 問題なし |
| 4 | OL Sending | MEDIUM | canvas描画内容がdestroy後も残留 | ✅ 修正済 |
| 5 | netlify.toml | OK | `/result/` redirect force=true 設定済 | ✅ 問題なし |
| 6 | OL Share | OK | `olSetShareData()` 実装済み | ✅ 問題なし |

## Test plan
- [ ] OL Sending 画面でパルスリングが画面中央の280px四方に収まること
- [ ] モバイル（375px幅）でもリングが比例縮小されること
- [ ] Sending→Result 遷移���に緑の背景やcanvasアーティファクトが残らないこと
- [ ] Result 画面のチェックマーク演出・カード表示が正常なこと
- [ ] OL Compose 画面のオシロスコープcanvasが正常に描画されること
- [ ] 「SEND ANOTHER」→ Compose 画面への戻りが正常なこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)