### PR TITLE
fix(admin): cache-busting + DB error handling + tab bug fixes

### DIFF
--- a/netlify/functions/admin-auth.js
+++ b/netlify/functions/admin-auth.js
@@ -6,6 +6,7 @@ exports.handler = async (event) => {
   const CORS_HEADERS = {
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
     'Content-Type': 'application/json'
   };
 

--- a/public/admin.js
+++ b/public/admin.js
@@ -109,7 +109,7 @@ Admin.UI = {
       '%;background:' + (c || 'var(--ok)') + ';opacity:.6"></div></div>';
   },
   status: function(t, y) {
-    var colors = { match: 'var(--ok)', fallback: 'var(--danger)', waiting: 'var(--warn)', expired: 'var(--admin-text-dim)' };
+    var colors = { matched: 'var(--ok)', fallback: 'var(--danger)', waiting: 'var(--warn)', expired: 'var(--admin-text-dim)' };
     return '<span style="color:' + (colors[y] || 'var(--admin-text-dim)') + ';font-size:11px">' + t + '</span>';
   },
   dot: function(c) { return '<span class="adm-dot" style="background:' + c + '"></span>'; },

--- a/public/admin.js
+++ b/public/admin.js
@@ -303,7 +303,8 @@ Admin.Tabs.register('ol', {
       });
       var memArr = Object.keys(memberOL).map(function(m) {
         var d = memberOL[m];
-        return { id: m, name: memberName(m), color: memberColor(m), sent: d.sent, matched: d.matched, fallback: d.fallback, total: d.sent + d.matched + d.fallback };
+        var w = d.sent - d.matched - d.fallback;
+        return { id: m, name: memberName(m), color: memberColor(m), waiting: w, matched: d.matched, fallback: d.fallback, total: d.sent };
       }).sort(function(a, b) { return b.total - a.total; });
       var mxM = Math.max.apply(null, memArr.map(function(m) { return m.total; }).concat([1]));
 
@@ -347,7 +348,7 @@ Admin.Tabs.register('ol', {
             U.dot(m.color) +
             '<span style="width:52px;font-family:var(--f-ui);font-size:12px;font-weight:600;color:' + m.color + '">' + m.name + '</span>' +
             '<div class="adm-sbar" style="flex:1">' +
-            '<div style="flex:' + m.sent + ';background:' + m.color + ';opacity:.55;height:100%"></div>' +
+            '<div style="flex:' + m.waiting + ';background:' + m.color + ';opacity:.55;height:100%"></div>' +
             '<div style="flex:' + m.matched + ';background:var(--ok);opacity:.45;height:100%"></div>' +
             '<div style="flex:' + m.fallback + ';background:var(--danger);opacity:.35;height:100%"></div></div>' +
             '<span style="font-family:var(--f-ui);font-size:12px;font-weight:600;width:24px;text-align:right">' + m.total + '</span></div>';

--- a/public/admin.js
+++ b/public/admin.js
@@ -241,9 +241,9 @@ Admin.Tabs.register('songs', {
         '<div class="adm-section">' + U.section('Quick stats') +
         '<div class="adm-grid adm-grid-4">' +
         U.metric(totalCount.toLocaleString(), 'Total songs') +
-        U.metric(unlinkedCount, 'Unlinked albums', { status: unlinkedCount > 50 ? 'warn' : '' }) +
-        U.metric(dupCount, 'Duplicate URLs', { status: dupCount > 0 ? 'danger' : '' }) +
-        U.metric(albumCount, 'Albums') +
+        U.metric(unlinkedCount.toLocaleString(), 'Unlinked albums', { status: unlinkedCount > 50 ? 'warn' : '' }) +
+        U.metric(dupCount.toLocaleString(), 'Duplicate URLs', { status: dupCount > 0 ? 'danger' : '' }) +
+        U.metric(albumCount.toLocaleString(), 'Albums') +
         '</div></div>' +
 
         '<div class="adm-section">' + U.section('Content freshness', U.badge('live', 'info')) +

--- a/public/admin.js
+++ b/public/admin.js
@@ -380,6 +380,17 @@ Admin.Tabs.register('ol', {
   }
 });
 
+/* ═══ Tab: GA4 ═══ */
+Admin.Tabs.register('ga4', {
+  label: 'GA4', order: 30,
+  render: function(el) {
+    el.innerHTML =
+      '<div class="adm-section">' + Admin.UI.section('Google Analytics') +
+      Admin.UI.note('GA4 integration is not yet configured. Visit the <a href="https://analytics.google.com" target="_blank" rel="noopener" style="color:var(--info)">Google Analytics dashboard</a> for traffic data.') +
+      '</div>';
+  }
+});
+
 /* ═══ Tab: HEALTH ═══ */
 Admin.Tabs.register('health', {
   label: 'HEALTH', order: 40,


### PR DESCRIPTION
## 発見された問題一覧

| # | カテゴリ | 重要度 | 問題 | 状態 |
|---|---------|--------|------|------|
| 1 | デプロイ | CRITICAL | admin.js/css にキャッシュバスティングなし。`max-age=86400, stale-while-revalidate=604800` で最大7日間古いJSが配信される。**「前回の修正が反映されない」の根本原因** | ✅ `admin.js?v=3` / `admin.css?v=3` 追加 |
| 2 | デプロイ | CRITICAL | `/admin*` に `must-revalidate` ヘッダーなし。`for = "/"` のみ | ✅ netlify.toml に `/admin*` ルール追加 |
| 3 | DB | CRITICAL | `query()` が `!res.ok` 後も `res.json()` を実行。非JSONレスポンス(502等)で throw → `.forEach` ガードに到達不能 | ✅ `!res.ok` で即 `return []` |
| 4 | DB | HIGH | `rpc()` にエラーハンドリング皆無 | ✅ `!res.ok` チェック追加 |
| 5 | UI | HIGH | `Admin.UI.status()` 色キー `match` ≠ DB値 `matched` | ✅ 修正済み |
| 6 | OL | HIGH | メンバー内訳二重計上 (`total = sent + matched + fallback`) | ✅ `total = sent`、棒グラフ `waiting` セグメント使用 |
| 7 | UI | MEDIUM | `.toLocaleString()` 一部メトリクス欠落 | ✅ 追加済み |
| 8 | Tab | MEDIUM | GA4 タブ未実装 (order 30 欠番) | ✅ プレースホルダー追加 |
| 9 | Auth | LOW | `Access-Control-Allow-Methods` 欠落 | ✅ 追加済み |

## 分析

全3タブの `.forEach is not a function` エラーの原因は **#1 + #3 の複合**:
- PR#100 のDB修正は main に入っているが、**キャッシュバスティングがないため古い admin.js が配信され続けていた** (#1)
- さらに PR#100 の修正自体も `!res.ok` で `return` せず `res.json()` を続行するため、非JSONレスポンス時に `!Array.isArray` ガードに到達できなかった (#3)

## コミット一覧 (7 commits)

1. `fix: correct status color key 'match' → 'matched'`
2. `fix: correct OL member breakdown double-counting`
3. `fix: add .toLocaleString() to remaining song metrics`
4. `feat: add GA4 placeholder tab at order 30`
5. `fix: add Access-Control-Allow-Methods to CORS headers`
6. `fix: add cache-busting and must-revalidate for admin assets`
7. `fix: return early on HTTP error in query() and add rpc() guard`

## Test plan
- [ ] デプロイ後、Ctrl+Shift+R で admin.js?v=3 がロードされることをDevToolsのNetworkタブで確認
- [ ] ログイン → ブートシーケンス → メイン画面遷移
- [ ] SONGS タブ: メトリクスがフォーマット付きで表示、`.forEach` エラーなし
- [ ] OL タブ: メンバー内訳の合計値が正しい（二重計上なし）、matched が緑表示
- [ ] GA4 タブ: プレースホルダーが表示
- [ ] HEALTH タブ: DB カウント + Content freshness が表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)