### PR TITLE
fix(admin): cache-busting + DB early return — .forEach永続エラー解決

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -50,6 +50,11 @@
   [headers.values]
     Cache-Control = "public, max-age=0, must-revalidate"
 
+[[headers]]
+  for = "/admin*"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
 # Fonts — long cache
 [[headers]]
   for = "/*.woff2"

--- a/public/admin.html
+++ b/public/admin.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>V.W.P ARCHIVE — Admin</title>
 <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Barlow+Condensed:wght@300;400;600;700&family=Noto+Sans+JP:wght@300;400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="admin.css">
+<link rel="stylesheet" href="admin.css?v=3">
 </head>
 <body>
 
@@ -46,6 +46,6 @@
   <main class="tab-content" id="tab-content"></main>
 </div>
 
-<script src="admin.js"></script>
+<script src="admin.js?v=3"></script>
 </body>
 </html>

--- a/public/admin.js
+++ b/public/admin.js
@@ -71,11 +71,12 @@ Admin.DB = (() => {
     var h = headers();
     var res = await fetch(url, { headers: h });
     if (!res.ok) {
-      console.error('[Admin.DB] HTTP ' + res.status + ' for ' + table + ' (' + url + ')');
+      console.error('[Admin.DB] HTTP ' + res.status + ' for ' + table);
+      return [];
     }
     var data = await res.json();
     if (!Array.isArray(data)) {
-      console.error('[Admin.DB] non-array response:', table, url, data);
+      console.error('[Admin.DB] non-array response:', table, data);
       return [];
     }
     return data;
@@ -87,6 +88,10 @@ Admin.DB = (() => {
       headers: Object.assign({ 'Content-Type': 'application/json' }, headers()),
       body: JSON.stringify(params || {})
     });
+    if (!res.ok) {
+      console.error('[Admin.DB] RPC ' + fnName + ' failed: HTTP ' + res.status);
+      return null;
+    }
     return res.json();
   }
 


### PR DESCRIPTION
## なぜデプロイしても .forEach エラーが直らないのか

**根本原因: ブラウザキャッシュ**

```
admin.html:  <script src="admin.js">     ← バージョンパラメータなし
netlify.toml: max-age=86400, stale-while-revalidate=604800  ← 最大7日キャッシュ
```

PR#100 で `!Array.isArray` ガードを admin.js に追加したが、**admin.html にキャッシュバスティングがないため、ブラウザはガード追加前の古い admin.js をキャッシュから配信し続けていた**。Netlify CDN は deploy 時に無効化されるが、ブラウザのローカルキャッシュは `max-age` に従って保持される。

さらに `/admin.html` 自体にも `must-revalidate` が適用されていなかった（`for = "/"` のみ）。

## 修正内容

| ファイル | 修正 |
|---------|------|
| `admin.html` | `admin.css?v=3` / `admin.js?v=3` — キャッシュバスティング |
| `netlify.toml` | `/admin*` に `must-revalidate` ヘッダー追加 |
| `admin.js` query() | `!res.ok` で即 `return []`（以前はログだけ出して `res.json()` を続行→非JSONで throw） |
| `admin.js` rpc() | `!res.ok` ガード追加（エラーハンドリングなしだった） |

## 確認手順
1. マージ → Netlify デプロイ完了を待つ
2. DevTools Network タブで `admin.js?v=3` がロードされていることを確認
3. 全タブで `.forEach` エラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)