### PR TITLE
fix(admin): エラー可視化 + DB診断 — データ取得失敗の原因を表示

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>V.W.P ARCHIVE — Admin</title>
 <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Barlow+Condensed:wght@300;400;600;700&family=Noto+Sans+JP:wght@300;400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="admin.css?v=3">
+<link rel="stylesheet" href="admin.css?v=4">
 </head>
 <body>
 
@@ -46,6 +46,6 @@
   <main class="tab-content" id="tab-content"></main>
 </div>
 
-<script src="admin.js?v=3"></script>
+<script src="admin.js?v=4"></script>
 </body>
 </html>

--- a/public/admin.js
+++ b/public/admin.js
@@ -55,6 +55,7 @@ Admin.Auth = (() => {
 Admin.DB = (() => {
   function headers() {
     const t = Admin.Auth.getToken();
+    if (!t) throw new Error('No auth token — check SUPABASE_SECRET_KEY env var or re-login');
     return { 'apikey': t, 'Authorization': 'Bearer ' + t };
   }
 
@@ -64,20 +65,22 @@ Admin.DB = (() => {
     var filter = p.filter || '';
     var order = p.order || '';
     var limit = p.limit || '';
-    var url = Admin.Auth.getUrl() + '/rest/v1/' + table + '?select=' + encodeURIComponent(select);
+    var base = Admin.Auth.getUrl();
+    if (!base) throw new Error('Supabase URL is not set — check SUPABASE_URL env var');
+    var url = base + '/rest/v1/' + table + '?select=' + encodeURIComponent(select);
     if (filter) url += '&' + filter;
     if (order) url += '&order=' + order;
     if (limit) url += '&limit=' + limit;
     var h = headers();
     var res = await fetch(url, { headers: h });
     if (!res.ok) {
-      console.error('[Admin.DB] HTTP ' + res.status + ' for ' + table);
-      return [];
+      var detail = '';
+      try { var b = await res.json(); detail = b.message || b.msg || JSON.stringify(b); } catch(e) { detail = res.statusText; }
+      throw new Error('HTTP ' + res.status + ' on ' + table + ': ' + detail);
     }
     var data = await res.json();
     if (!Array.isArray(data)) {
-      console.error('[Admin.DB] non-array response:', table, data);
-      return [];
+      throw new Error(table + ' returned non-array: ' + JSON.stringify(data).slice(0, 200));
     }
     return data;
   }
@@ -89,8 +92,9 @@ Admin.DB = (() => {
       body: JSON.stringify(params || {})
     });
     if (!res.ok) {
-      console.error('[Admin.DB] RPC ' + fnName + ' failed: HTTP ' + res.status);
-      return null;
+      var detail = '';
+      try { var b = await res.json(); detail = b.message || JSON.stringify(b); } catch(e) { detail = res.statusText; }
+      throw new Error('RPC ' + fnName + ' HTTP ' + res.status + ': ' + detail);
     }
     return res.json();
   }


### PR DESCRIPTION
## 問題
PR#104 マージ後、管理画面は表示されるようになったが全タブのデータが 0 のまま。
DB クエリが失敗しているが、\`return []\` でエラーを隠していたため原因が分からな��った。

## 修正

### エラーの可視化（silent return [] → throw）
```diff
 if (!res.ok) {
-  console.error(...)
-  return [];  // ← エラーが隠れる、全て 0 表示
+  var detail = await res.json().message ...
+  throw new Error('HTTP ' + res.status + ' on ' + table + ': ' + detail);
+  // ← catch(e) でユーザーに実際のエラーを表示
 }
```

### 事前バリデーション
- `getUrl()` が null/空 → `Supabase URL is not set — check SUPABASE_URL env var`
- `getToken()` が null/空 → `No auth token — check SUPABASE_SECRET_KEY env var or re-login`

### 表示されるエラー例
| 原因 | 表示メッセージ |
|------|---------------|
| API キー無効 | `HTTP 401 on videos: Invalid API key` |
| テーブル不在 | `HTTP 404 on albums: relation "public.albums" does not exist` |
| URL 未設定 | `Supabase URL is not set — check SUPABASE_URL env var` |
| トークン未設定 | `No auth token — check SUPABASE_SECRET_KEY env var or re-login` |

## マージ後の確認手順
1. マージ → デプロイ
2. admin ページを開く（DevTools Console も���く）
3. ログイン後、各タブに**赤いエラーメッセージ**が表示されるはず
4. そのエラーメッセージの内容で次の対処が決まる:
   - `HTTP 401` → Netlify 環境変数 `SUPABASE_SECRET_KEY` を確認
   - `HTTP 404` → テーブル名確認
   - `Supabase URL is not set` → Netlify 環境変数 `SUPABASE_URL` を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)