### PR TITLE
fix(admin): proxy DB queries server-side — secret key browser ban

### DIFF
--- a/netlify/functions/admin-auth.js
+++ b/netlify/functions/admin-auth.js
@@ -1,6 +1,9 @@
 // POST /.netlify/functions/admin-auth
 // Body: { password: string }
-// Response: { ok: true, token: string, supabase_url: string } | { ok: false, msg: string }
+// Response: { ok: true, token: string } | { ok: false, msg: string }
+// token is a SHA-256 session hash (NOT the Supabase secret key — that stays server-side)
+
+const crypto = require('crypto');
 
 exports.handler = async (event) => {
   const CORS_HEADERS = {
@@ -33,13 +36,16 @@ exports.handler = async (event) => {
       };
     }
 
+    const sessionToken = crypto.createHash('sha256')
+      .update(process.env.ADMIN_PASSWORD)
+      .digest('hex');
+
     return {
       statusCode: 200,
       headers: CORS_HEADERS,
       body: JSON.stringify({
         ok: true,
-        token: process.env.SUPABASE_SECRET_KEY,
-        supabase_url: process.env.SUPABASE_URL
+        token: sessionToken
       })
     };
   } catch (e) {

--- a/netlify/functions/admin-query.js
+++ b/netlify/functions/admin-query.js
@@ -1,0 +1,74 @@
+// POST /.netlify/functions/admin-query
+// Headers: Authorization: Bearer <session_token>
+// Body: { table, select, filter, order, limit }
+// Response: JSON array from Supabase (proxied server-side with secret key)
+
+const crypto = require('crypto');
+
+exports.handler = async (event) => {
+  const CORS = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Content-Type': 'application/json'
+  };
+
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS, body: '' };
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, headers: CORS, body: JSON.stringify({ error: 'Method not allowed' }) };
+  }
+
+  // Verify session token (SHA-256 hash of ADMIN_PASSWORD)
+  const auth = (event.headers.authorization || '').replace(/^Bearer\s+/i, '');
+  const expected = crypto.createHash('sha256')
+    .update(process.env.ADMIN_PASSWORD || '')
+    .digest('hex');
+
+  if (!auth || auth !== expected) {
+    return { statusCode: 401, headers: CORS, body: JSON.stringify({ error: 'Unauthorized — invalid session' }) };
+  }
+
+  try {
+    const { table, select, filter, order, limit } = JSON.parse(event.body);
+
+    if (!table) {
+      return { statusCode: 400, headers: CORS, body: JSON.stringify({ error: 'table is required' }) };
+    }
+
+    const SUPABASE_URL = process.env.SUPABASE_URL;
+    const SUPABASE_KEY = process.env.SUPABASE_SECRET_KEY;
+
+    if (!SUPABASE_URL || !SUPABASE_KEY) {
+      return { statusCode: 500, headers: CORS, body: JSON.stringify({ error: 'SUPABASE_URL or SUPABASE_SECRET_KEY not configured' }) };
+    }
+
+    let url = SUPABASE_URL + '/rest/v1/' + table + '?select=' + encodeURIComponent(select || '*');
+    if (filter) url += '&' + filter;
+    if (order) url += '&order=' + order;
+    if (limit) url += '&limit=' + limit;
+
+    const res = await fetch(url, {
+      headers: {
+        apikey: SUPABASE_KEY,
+        Authorization: 'Bearer ' + SUPABASE_KEY
+      }
+    });
+
+    const data = await res.json();
+
+    return {
+      statusCode: res.status,
+      headers: CORS,
+      body: JSON.stringify(data)
+    };
+  } catch (e) {
+    return {
+      statusCode: 500,
+      headers: CORS,
+      body: JSON.stringify({ error: e.message })
+    };
+  }
+};

--- a/public/admin.html
+++ b/public/admin.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>V.W.P ARCHIVE — Admin</title>
 <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Barlow+Condensed:wght@300;400;600;700&family=Noto+Sans+JP:wght@300;400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="admin.css?v=4">
+<link rel="stylesheet" href="admin.css?v=5">
 </head>
 <body>
 
@@ -46,6 +46,6 @@
   <main class="tab-content" id="tab-content"></main>
 </div>
 
-<script src="admin.js?v=4"></script>
+<script src="admin.js?v=5"></script>
 </body>
 </html>

--- a/public/admin.js
+++ b/public/admin.js
@@ -16,7 +16,6 @@ const Admin = {};
 /* ═══ Auth ═══ */
 Admin.Auth = (() => {
   let _token = sessionStorage.getItem('admin_token');
-  let _supabaseUrl = sessionStorage.getItem('admin_supabase_url');
 
   return {
     async login(password) {
@@ -29,9 +28,7 @@ Admin.Auth = (() => {
         const data = await res.json();
         if (data.ok) {
           _token = data.token;
-          _supabaseUrl = data.supabase_url;
           sessionStorage.setItem('admin_token', _token);
-          sessionStorage.setItem('admin_supabase_url', _supabaseUrl);
           return { ok: true };
         }
         return { ok: false, msg: data.msg || 'ACCESS DENIED' };
@@ -41,41 +38,37 @@ Admin.Auth = (() => {
     },
     logout() {
       _token = null;
-      _supabaseUrl = null;
       sessionStorage.removeItem('admin_token');
       sessionStorage.removeItem('admin_supabase_url');
     },
-    isAuthed() { return !!_token && !!_supabaseUrl; },
-    getToken() { return _token; },
-    getUrl() { return _supabaseUrl; }
+    isAuthed() { return !!_token; },
+    getToken() { return _token; }
   };
 })();
 
 /* ═══ DB ═══ */
 Admin.DB = (() => {
-  function headers() {
-    const t = Admin.Auth.getToken();
-    if (!t) throw new Error('No auth token — check SUPABASE_SECRET_KEY env var or re-login');
-    return { 'apikey': t, 'Authorization': 'Bearer ' + t };
-  }
-
   async function query(table, params) {
     var p = params || {};
-    var select = p.select || '*';
-    var filter = p.filter || '';
-    var order = p.order || '';
-    var limit = p.limit || '';
-    var base = Admin.Auth.getUrl();
-    if (!base) throw new Error('Supabase URL is not set — check SUPABASE_URL env var');
-    var url = base + '/rest/v1/' + table + '?select=' + encodeURIComponent(select);
-    if (filter) url += '&' + filter;
-    if (order) url += '&order=' + order;
-    if (limit) url += '&limit=' + limit;
-    var h = headers();
-    var res = await fetch(url, { headers: h });
+    var token = Admin.Auth.getToken();
+    if (!token) throw new Error('No session token — please re-login');
+    var res = await fetch('/.netlify/functions/admin-query', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + token
+      },
+      body: JSON.stringify({
+        table: table,
+        select: p.select || '*',
+        filter: p.filter || '',
+        order: p.order || '',
+        limit: p.limit || ''
+      })
+    });
     if (!res.ok) {
       var detail = '';
-      try { var b = await res.json(); detail = b.message || b.msg || JSON.stringify(b); } catch(e) { detail = res.statusText; }
+      try { var b = await res.json(); detail = b.error || b.message || JSON.stringify(b); } catch(e) { detail = res.statusText; }
       throw new Error('HTTP ' + res.status + ' on ' + table + ': ' + detail);
     }
     var data = await res.json();
@@ -85,21 +78,7 @@ Admin.DB = (() => {
     return data;
   }
 
-  async function rpc(fnName, params) {
-    var res = await fetch(Admin.Auth.getUrl() + '/rest/v1/rpc/' + fnName, {
-      method: 'POST',
-      headers: Object.assign({ 'Content-Type': 'application/json' }, headers()),
-      body: JSON.stringify(params || {})
-    });
-    if (!res.ok) {
-      var detail = '';
-      try { var b = await res.json(); detail = b.message || JSON.stringify(b); } catch(e) { detail = res.statusText; }
-      throw new Error('RPC ' + fnName + ' HTTP ' + res.status + ': ' + detail);
-    }
-    return res.json();
-  }
-
-  return { query: query, rpc: rpc };
+  return { query: query };
 })();
 
 /* ═══ UI ═══ */


### PR DESCRIPTION
## 問題
`Failed to load song data: HTTP 401 on videos: Forbidden use of secret API key in browser`

Supabase がブラウザからの service_role key 使用をセキュリティ上の理由でブロックしている。
現在の admin-auth は secret key をそのままブラウザに渡し、ブラウザが Supabase REST API に直接クエリしていた。

## アーキテクチャ変更

```
BEFORE (ブロックされる):
  Browser → admin-auth → 秘密鍵を受け取る → Supabase直接クエリ ← 401 BLOCKED

AFTER (修正後):
  Browser → admin-auth → セッションハッシュを受け取る
  Browser → admin-query (Netlify Function) → 秘密鍵でサーバー側クエリ → 結果返却
```

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `admin-auth.js` | `SUPABASE_SECRET_KEY` の代わりに `SHA-256(ADMIN_PASSWORD)` をセッショントークンとして返す |
| `admin-query.js` | **新規** — セッショントークン検証 → Supabase に秘密鍵でサーバー側クエリ → 結果を中継 |
| `admin.js` | `DB.query()` が `/.netlify/functions/admin-query` を POST で呼び出すように変更。`getUrl()`、`rpc()`、`supabase_url` を削除 |
| `admin.html` | キャッシュバスティング `?v=5` |

## 注意
- 既存���ッションは無効化される（トークンが secret key → hash に変わるため）
- **デプロイ後、一度ログアウト → 再ログインが必要**

🤖 Generated with [Claude Code](https://claude.com/claude-code)