### PR TITLE
fix(admin): PostgREST デフォルト1000件制限で videos が取りこぼされる問題を修正

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -52,6 +52,6 @@
 
 <div id="modal-root"></div>
 
-<script src="admin.js?v=7"></script>
+<script src="admin.js?v=8"></script>
 </body>
 </html>

--- a/public/admin.js
+++ b/public/admin.js
@@ -616,7 +616,7 @@ MU.Tabs.register('ol', {
           select: 'id,status,video_id,matched_with,fallback_video_id,created_at,client_hash,message',
           order: 'created_at.desc', limit: '50'
         }),
-        MU.DB.query('videos', { select: 'id,title,member' })
+        MU.DB.query('videos', { select: 'id,title,member', limit: '9999' })
       ]);
       var allBottles = results[0];
       var recentBottles = results[1];


### PR DESCRIPTION
## 概要
Admin Panel の OBSERVER-LINK タブで video タイトルが `?` と表示されていた問題を修正。

## 原因
`MU.DB.query('videos', { select: 'id,title,member' })` に `limit` が未指定だったため、PostgREST デフォルトの暗黙 limit 1000 に引っかかり、id 1066 以降の221件の videos が `vidMap` に入っていなかった。

## 修正
- OL タブの videos クエリに `limit: '9999'` を追加（`admin.js:619`）
- キャッシュバスター `admin.js?v=7` → `?v=8`

## 動作確認
- [ ] OL タブで video_id 1248, 1351, 1361〜1363 のボトルが正しいタイトルで表示される
- [ ] Network タブで videos レスポンスが 1,286件返っていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)