### PR TITLE
fix(observer-link): フォールバック推薦時に受信曲情報を DB へ永続化

### DIFF
--- a/netlify/functions/observer-link-exchange.js
+++ b/netlify/functions/observer-link-exchange.js
@@ -205,7 +205,7 @@ exports.handler = async (event) => {
         {
           method: 'PATCH',
           headers: sbHeaders,
-          body: JSON.stringify({ status: 'fallback', fallback_video_id: recommended.id }),
+          body: JSON.stringify({ status: 'fallback_matched', fallback_video_id: recommended.id }),
         }
       );
     }

--- a/netlify/functions/observer-link-result.js
+++ b/netlify/functions/observer-link-result.js
@@ -58,7 +58,7 @@ exports.handler = async (event) => {
     }
 
     // Handle fallback recommendations
-    if (bottle.status === 'fallback' && bottle.fallback_video_id) {
+    if (bottle.status === 'fallback_matched' && bottle.fallback_video_id) {
       const fbVideoRes = await fetch(
         `${url}/rest/v1/videos?select=id,title,member,date,url&id=eq.${bottle.fallback_video_id}`,
         { headers: sbHeaders }
@@ -68,6 +68,11 @@ exports.handler = async (event) => {
       if (fbVideo) {
         return fallbackResultPage(siteUrl, id, sentVideo, bottle, fbVideo);
       }
+    }
+
+    // Waiting bottles: still floating
+    if (bottle.status === 'waiting') {
+      return waitingPage(siteUrl, sentVideo, bottle);
     }
 
     // Unmatched bottles should not render a success page
@@ -252,6 +257,83 @@ a:hover{background:rgba(196,181,253,.1)}
   return {
     statusCode: 404,
     headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    body: html,
+  };
+}
+
+function waitingPage(siteUrl, sentVideo, bottle) {
+  const sentYtId = sentVideo ? extractYtId(sentVideo.url) : '';
+  const sentThumb = sentYtId ? `https://img.youtube.com/vi/${sentYtId}/mqdefault.jpg` : '';
+  const sentMemberName = getMemberDisplay(sentVideo?.member || '');
+  const sentColor = getMemberColor(sentVideo?.member || '');
+
+  const sentCardHtml = sentVideo ? `
+    <div class="card">
+      <div class="card-label yours">YOUR RECORD</div>
+      <div class="card-content">
+        ${sentThumb ? `<img class="card-thumb" src="${escHtml(sentThumb)}" alt="">` : ''}
+        <div>
+          <div class="card-member" style="color:${sentColor}">${escHtml(sentMemberName)}</div>
+          <div class="card-title">${escHtml(sentVideo.title || '')}</div>
+        </div>
+      </div>
+      ${bottle.message ? `<div class="card-msg">${escHtml(bottle.message)}</div>` : ''}
+    </div>` : '';
+
+  const html = `<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Observer-Link — V.W.P ARCHIVE</title>
+<meta property="og:title" content="Observer-Link — V.W.P ARCHIVE">
+<meta property="og:description" content="Your record is still floating in the sea...">
+<meta property="og:image" content="${siteUrl}/ogp-observer-link.png">
+<meta name="twitter:card" content="summary">
+<link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Shippori+Mincho:wght@400;600&family=Barlow+Condensed:wght@300;400;600;700&family=Noto+Sans+JP:wght@300;400;500&display=swap" rel="stylesheet">
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{background:#07090e;color:#e8ecf8;font-family:'Noto Sans JP','Barlow Condensed',sans-serif;min-height:100vh;display:flex;flex-direction:column;align-items:center}
+.container{max-width:430px;width:100%;padding:20px}
+.header{text-align:center;padding:20px 0}
+.logo{font-family:'Cinzel',serif;font-size:10px;letter-spacing:2.5px;color:rgba(232,236,248,.45);text-transform:uppercase}
+.logo span{font-size:7px;letter-spacing:1.5px;display:block;margin-top:2px;color:rgba(232,236,248,.22)}
+.intro{text-align:center;margin:24px 0 20px}
+.intro-icon{font-size:36px;margin-bottom:12px}
+.intro-title{font-family:'Shippori Mincho',serif;font-size:18px;font-weight:600;background:linear-gradient(135deg,#e8ecf8,#6c5ce7);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;color:transparent}
+.intro-sub{font-size:12px;color:rgba(232,236,248,.38);margin-top:8px;line-height:1.6}
+.card{background:#0c0f18;border:1px solid rgba(255,255,255,.10);border-radius:16px;overflow:hidden;margin-bottom:14px}
+.card-label{font-family:'Barlow Condensed',sans-serif;font-size:10px;font-weight:600;letter-spacing:2px;text-transform:uppercase;padding:12px 16px 0}
+.card-label.yours{color:#c4b5fd}
+.card-content{display:flex;align-items:center;gap:14px;padding:10px 16px 14px}
+.card-thumb{width:64px;height:64px;border-radius:10px;object-fit:cover;flex-shrink:0}
+.card-member{font-family:'Barlow Condensed',sans-serif;font-size:10px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase}
+.card-title{font-family:'Shippori Mincho',serif;font-size:15px;margin-top:2px}
+.card-msg{padding:0 16px 14px;font-size:12px;color:rgba(232,236,248,.45);font-style:italic}
+.card-msg::before{content:'\\300C'}
+.card-msg::after{content:'\\300D'}
+.cta{display:block;text-align:center;padding:16px;background:linear-gradient(135deg,#4a3a8a,#6c5ce7);color:#fff;border-radius:16px;font-family:'Barlow Condensed',sans-serif;font-size:15px;font-weight:600;letter-spacing:2px;text-transform:uppercase;text-decoration:none;margin-top:20px}
+</style>
+</head>
+<body>
+<div class="container">
+  <div class="header">
+    <div class="logo">V.W.P ARCHIVE<span>UNOFFICIAL &mdash; OBSERVER-LINK</span></div>
+  </div>
+  <div class="intro">
+    <div class="intro-icon">&#127754;</div>
+    <div class="intro-title">Your record is still floating in the sea\u2026</div>
+    <div class="intro-sub">Waiting to be found by another observer</div>
+  </div>
+  ${sentCardHtml}
+  <a class="cta" href="${siteUrl}">Back to Observer-Link</a>
+</div>
+</body>
+</html>`;
+
+  return {
+    statusCode: 200,
+    headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' },
     body: html,
   };
 }


### PR DESCRIPTION
## 概要
Observer-Link のフォールバック推薦（waiting プールが空のときのランダム推薦）が DB に記録されず、シェア URL から result ページにアクセスしても「期限切れ」エラーになっていた問題を修正。

## 根本原因
exchange Function が `status: 'fallback'` を設定していたが、DB の CHECK 制約が `('waiting', 'matched', 'fallback_matched')` に更新されたため PATCH が失敗し、ボトルが `status='waiting'`, `fallback_video_id=null` のまま放置されていた。

## 修正内容
1. **exchange Function**: `status: 'fallback'` → `status: 'fallback_matched'`（CHECK 制約に合致）
2. **result Function**: `bottle.status === 'fallback'` → `'fallback_matched'` に修正
3. **result Function**: `status === 'waiting'` のボトル用に waiting ページを追加（「Your record is still floating in the sea...」+ 送信曲カード）

## 旧バグ再発防止
- waiting プール SELECT は `WHERE status='waiting'` 固定なので、`'fallback_matched'` は自動的に除外される
- DB CHECK 制約の `'fallback_matched'` は migration で適用済み

## 動作確認
- [ ] fallback match パターンの result ページで受信曲が正しく表示される
- [ ] 既存の応急修復済み URL `?id=d6c82e59-...` が復活
- [ ] waiting ボトルで waiting ページが表示される（期限切れではなく）
- [ ] mutual match の result ページに影響なし
- [ ] X シェア → クリックのフルループ

🤖 Generated with [Claude Code](https://claude.com/claude-code)