### PR TITLE
feat(ingest): YouTube自動取り込みパイプライン + status列導入に伴う公開/admin整備

### DIFF
--- a/docs/VWP_ARCHIVE_unified_spec.md
+++ b/docs/VWP_ARCHIVE_unified_spec.md
@@ -52,8 +52,32 @@
 ### データ構造（Supabase videos テーブル）
 ```
 id, member (スペース区切り: "kafu rime"), title, url, date, tags (スペース区切り: "シングル アニメ"),
-note, spotify_url, album_id
+note, spotify_url, album_id,
+status TEXT NOT NULL DEFAULT 'published' CHECK (status IN ('published','pending','rejected')),
+content_type TEXT NOT NULL DEFAULT 'song' CHECK (content_type IN ('song','live','shorts','announcement')),
+source TEXT DEFAULT 'manual',
+ingested_at TIMESTAMPTZ
 ```
+
+**status フィールドの運用ルール:**
+- `published`: 公開。公開系videos取得クエリでのみ返却される（`status=eq.published` フィルタ必須）
+- `pending`: 自動取り込み後の審査待ち。Admin INCOMINGキューで確認・PUBLISH/REJECT操作を行う
+- `rejected`: 不採用。DBには残すが公開しない
+- **自動publishは永久にしない（絶対条件10番）**: ingest-youtubeは常に`pending`でINSERTする
+
+**content_type フィールド（ingest-youtubeによる自動分類）:**
+- `shorts`: duration ≤ 60秒 または #shorts タグ
+- `live`: liveStreamingDetails あり または ライブ系キーワード（ワンマン/ライブ映像/LIVE/不可解/現象/狂想）
+- `announcement`: 告知系キーワード（告知/トレーラー/Teaser/XFD/クロスフェード/予告/開催決定/発売決定/情報解禁）
+- `song`: 上記に該当しないもの（デフォルト）
+
+**ingest_channels テーブル（PR-A1で新規追加）:**
+```
+id SERIAL PK, member_id TEXT, channel_id TEXT UNIQUE,
+uploads_playlist_id TEXT, enabled BOOLEAN DEFAULT true,
+last_checked_at TIMESTAMPTZ, last_video_published_at TIMESTAMPTZ
+```
+Yukiがチャンネル行を手動INSERTして有効化する。
 
 ### メンバー定義
 | ID | 表示名 | Emoji | カラー | LP盤の見え方 |

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,9 @@
   publish = "public"
   functions = "netlify/functions"
 
+[functions."ingest-youtube"]
+  schedule = "0 */6 * * *"
+
 [[redirects]]
   from = "/result/"
   to = "/.netlify/functions/observer-link-result"

--- a/netlify/functions/ingest-youtube.js
+++ b/netlify/functions/ingest-youtube.js
@@ -230,11 +230,12 @@ exports.handler = async (event) => {
         const videoDetails = {};
         (vtData.items || []).forEach(v => { videoDetails[v.id] = v; });
 
-        // (e) Supabase で既存URL突合（全件fetch禁止 — idリストで絞り込み）
+        // (e) Supabase で既存URL突合（全件fetch禁止 — urlリストで絞り込み）
+        // 生成するURLは https://www.youtube.com/watch?v=VIDEOID 形式で & を含まないため安全
         const candidateUrls = videoIds.map(id => `https://www.youtube.com/watch?v=${id}`);
-        const encodedUrls = candidateUrls.map(u => encodeURIComponent(u)).join(',');
+        const inFilter = candidateUrls.map(u => `"${u}"`).join(',');
         const existingRes = await sbFetch(
-          `${SUPABASE_URL}/rest/v1/videos?select=url&url=in.(${candidateUrls.map(u => `"${u}"`).join(',')})`,
+          `${SUPABASE_URL}/rest/v1/videos?select=url&url=in.(${inFilter})`,
           { headers: { apikey: SUPABASE_KEY, Authorization: `Bearer ${SUPABASE_KEY}` } }
         );
         const existingUrls = new Set(

--- a/netlify/functions/ingest-youtube.js
+++ b/netlify/functions/ingest-youtube.js
@@ -1,0 +1,357 @@
+// ═══════════════════════════════════════════════════════════════
+// ingest-youtube.js — YouTube自動取り込みFunction
+// スケジュール: 6時間ごと (netlify.toml で設定)
+// 手動起動: Authorization: Bearer <ADMIN_PASSWORD> が必要
+// 自動publish禁止 — 取り込みは常に status='pending' 止まり
+// ═══════════════════════════════════════════════════════════════
+
+// ── キーワード定数辞書 ──
+const SHORTS_KEYWORDS = ['#shorts'];
+const LIVE_KEYWORDS = [
+  'ワンマン', 'ライブ映像', 'LIVE', '不可解', '現象', '狂想'
+];
+const ANNOUNCEMENT_KEYWORDS = [
+  '告知', 'トレーラー', 'Teaser', 'XFD', 'クロスフェード', '予告',
+  '開催決定', '発売決定', '情報解禁'
+];
+const COVER_KEYWORDS = ['Covered', '歌ってみた'];
+
+// メンバー名表記（タイトル中の他メンバー検出用）
+const MEMBER_TITLE_PATTERNS = {
+  kafu:    ['花譜', 'KAF', 'かふ'],
+  rime:    ['理芽', 'RIM', 'りめ'],
+  harusar: ['春猿火', 'HARUSARU', 'HARU'],
+  isekai:  ['ヰ世界情緒', 'JOUCHO', 'ヰよ'],
+  koko:    ['幸祜', 'KOKO', 'こうこ']
+};
+
+// ── ユーティリティ ──
+
+/**
+ * ISO 8601 duration (PT1M30S, PT45S 等) を秒数に変換
+ */
+function parseDuration(iso) {
+  if (!iso) return null;
+  const m = iso.match(/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/);
+  if (!m) return null;
+  return (parseInt(m[1] || 0) * 3600) + (parseInt(m[2] || 0) * 60) + parseInt(m[3] || 0);
+}
+
+/**
+ * タイトル + description からcontent_typeを判定
+ * 優先順: shorts → live → announcement → song
+ */
+function classifyContentType(title, description, durationSec, hasLiveDetails) {
+  const text = (title + ' ' + (description || '')).toLowerCase();
+  const titleLower = title.toLowerCase();
+
+  // shorts: 60秒以下 OR タイトル/descriptionに #shorts
+  if (
+    (durationSec !== null && durationSec <= 60) ||
+    SHORTS_KEYWORDS.some(k => text.includes(k.toLowerCase()))
+  ) {
+    return 'shorts';
+  }
+
+  // live: liveStreamingDetailsあり OR タイトルにライブ系キーワード
+  if (
+    hasLiveDetails ||
+    LIVE_KEYWORDS.some(k => titleLower.includes(k.toLowerCase()))
+  ) {
+    return 'live';
+  }
+
+  // announcement: タイトルに告知系キーワード
+  if (ANNOUNCEMENT_KEYWORDS.some(k => titleLower.includes(k.toLowerCase()))) {
+    return 'announcement';
+  }
+
+  return 'song';
+}
+
+/**
+ * タイトルに他メンバー名が含まれていれば追加
+ * 既存 "kafu rime" 形式で返す
+ */
+function resolveMember(primaryMemberId, title) {
+  const members = [primaryMemberId];
+  const titleStr = title || '';
+  for (const [memberId, patterns] of Object.entries(MEMBER_TITLE_PATTERNS)) {
+    if (memberId === primaryMemberId) continue;
+    if (patterns.some(p => titleStr.includes(p))) {
+      members.push(memberId);
+    }
+  }
+  // 重複除去 + ソート（一貫性のため）
+  return [...new Set(members)].sort().join(' ');
+}
+
+/**
+ * タイトルにカバー系キーワードが含まれていれば 'Covered' タグを返す
+ */
+function detectCoverTag(title) {
+  const t = title || '';
+  return COVER_KEYWORDS.some(k => t.includes(k)) ? 'Covered' : null;
+}
+
+/**
+ * Supabase fetch ラッパー（エラーはそのままthrow）
+ */
+async function sbFetch(url, options) {
+  const res = await fetch(url, options);
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Supabase ${res.status}: ${text.slice(0, 300)}`);
+  }
+  return res.json();
+}
+
+// ── メインハンドラ ──
+exports.handler = async (event) => {
+  const SUPABASE_URL = process.env.SUPABASE_URL;
+  const SUPABASE_KEY = process.env.SUPABASE_SECRET_KEY;
+  const YT_KEY = process.env.YOUTUBE_API_KEY;
+  const ADMIN_PW = process.env.ADMIN_PASSWORD;
+
+  if (!SUPABASE_URL || !SUPABASE_KEY || !YT_KEY) {
+    return { statusCode: 500, body: JSON.stringify({ error: '環境変数が不足しています' }) };
+  }
+
+  // ── 手動起動ガード ──
+  // Netlifyスケジュール実行: event.httpMethod が undefined または 'POST' で
+  // event.body に {"next_run":...} が含まれる。
+  // それ以外（HTTP直叩き）の場合は ADMIN_PASSWORD トークンを要求する。
+  const isScheduled = (
+    !event.httpMethod ||
+    (event.httpMethod === 'POST' && event.body && event.body.includes('next_run'))
+  );
+
+  if (!isScheduled) {
+    const authHeader = event.headers?.authorization || event.headers?.Authorization || '';
+    const token = authHeader.replace(/^Bearer\s+/i, '').trim();
+    if (!ADMIN_PW || token !== ADMIN_PW) {
+      return {
+        statusCode: 401,
+        body: JSON.stringify({ error: '手動起動には Authorization: Bearer <ADMIN_PASSWORD> が必要です' })
+      };
+    }
+  }
+
+  const sbHeaders = {
+    apikey: SUPABASE_KEY,
+    Authorization: `Bearer ${SUPABASE_KEY}`,
+    'Content-Type': 'application/json',
+    Prefer: 'return=representation'
+  };
+
+  const results = [];
+
+  try {
+    // (a) ingest_channels から enabled=true を取得
+    const channels = await sbFetch(
+      `${SUPABASE_URL}/rest/v1/ingest_channels?select=*&enabled=eq.true`,
+      { headers: sbHeaders }
+    );
+    if (!Array.isArray(channels) || channels.length === 0) {
+      return { statusCode: 200, body: JSON.stringify({ message: '有効なチャンネルがありません', results }) };
+    }
+
+    for (const channel of channels) {
+      try {
+        let uploadsPlaylistId = channel.uploads_playlist_id;
+
+        // (b) uploads_playlist_id 未解決なら YouTube channels.list で取得してキャッシュ
+        if (!uploadsPlaylistId) {
+          const chRes = await fetch(
+            `https://www.googleapis.com/youtube/v3/channels?part=contentDetails&id=${channel.channel_id}&key=${YT_KEY}`
+          );
+          const chData = await chRes.json();
+          uploadsPlaylistId = chData?.items?.[0]?.contentDetails?.relatedPlaylists?.uploads;
+          if (!uploadsPlaylistId) {
+            results.push({ channel_id: channel.channel_id, error: 'uploads_playlist_id を取得できませんでした' });
+            continue;
+          }
+          // PATCHでキャッシュ
+          await fetch(
+            `${SUPABASE_URL}/rest/v1/ingest_channels?id=eq.${channel.id}`,
+            {
+              method: 'PATCH',
+              headers: sbHeaders,
+              body: JSON.stringify({ uploads_playlist_id: uploadsPlaylistId })
+            }
+          );
+        }
+
+        // (c) playlistItems.list で新着取得（最大50件）
+        const plRes = await fetch(
+          `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&maxResults=50&playlistId=${uploadsPlaylistId}&key=${YT_KEY}`
+        );
+        const plData = await plRes.json();
+        if (plData.error) {
+          results.push({ channel_id: channel.channel_id, error: `YouTube API: ${plData.error.message}` });
+          continue;
+        }
+
+        const playlistItems = plData.items || [];
+
+        // last_video_published_at より新しいものだけ抽出
+        const cursor = channel.last_video_published_at ? new Date(channel.last_video_published_at) : null;
+        const newItems = playlistItems.filter(item => {
+          const pub = item.snippet?.publishedAt;
+          if (!pub) return false;
+          if (cursor && new Date(pub) <= cursor) return false;
+          return true;
+        });
+
+        if (newItems.length === 0) {
+          // カーソル更新のみ
+          await fetch(
+            `${SUPABASE_URL}/rest/v1/ingest_channels?id=eq.${channel.id}`,
+            {
+              method: 'PATCH',
+              headers: sbHeaders,
+              body: JSON.stringify({ last_checked_at: new Date().toISOString() })
+            }
+          );
+          results.push({ channel_id: channel.channel_id, new_items: 0, inserted: 0 });
+          continue;
+        }
+
+        // videoId リスト
+        const videoIds = newItems
+          .map(item => item.snippet?.resourceId?.videoId)
+          .filter(Boolean);
+
+        // (d) videos.list で duration / live 情報取得
+        const vtRes = await fetch(
+          `https://www.googleapis.com/youtube/v3/videos?part=snippet,contentDetails,liveStreamingDetails&id=${videoIds.join(',')}&key=${YT_KEY}`
+        );
+        const vtData = await vtRes.json();
+        const videoDetails = {};
+        (vtData.items || []).forEach(v => { videoDetails[v.id] = v; });
+
+        // (e) Supabase で既存URL突合（全件fetch禁止 — idリストで絞り込み）
+        const candidateUrls = videoIds.map(id => `https://www.youtube.com/watch?v=${id}`);
+        const encodedUrls = candidateUrls.map(u => encodeURIComponent(u)).join(',');
+        const existingRes = await sbFetch(
+          `${SUPABASE_URL}/rest/v1/videos?select=url&url=in.(${candidateUrls.map(u => `"${u}"`).join(',')})`,
+          { headers: { apikey: SUPABASE_KEY, Authorization: `Bearer ${SUPABASE_KEY}` } }
+        );
+        const existingUrls = new Set(
+          Array.isArray(existingRes) ? existingRes.map(v => v.url) : []
+        );
+
+        // (f) content_type分類 + member確定 + カバー検出
+        const toInsert = [];
+        let latestPublishedAt = cursor;
+
+        for (const videoId of videoIds) {
+          const url = `https://www.youtube.com/watch?v=${videoId}`;
+          if (existingUrls.has(url)) continue;
+
+          const detail = videoDetails[videoId];
+          if (!detail) continue;
+
+          const snippet = detail.snippet || {};
+          const contentDetails = detail.contentDetails || {};
+          const liveDetails = detail.liveStreamingDetails;
+
+          const title = snippet.title || '';
+          const description = snippet.description || '';
+          const publishedAt = snippet.publishedAt || null;
+          const durationSec = parseDuration(contentDetails.duration);
+          const hasLiveDetails = !!liveDetails;
+
+          const contentType = classifyContentType(title, description, durationSec, hasLiveDetails);
+          const member = resolveMember(channel.member_id, title);
+          const coverTag = detectCoverTag(title);
+
+          // タグは 'Covered' のみ自動付与（他は空）
+          const tags = coverTag || '';
+
+          const date = publishedAt ? publishedAt.slice(0, 10) : null;
+
+          toInsert.push({
+            url,
+            title,
+            date,
+            member,
+            tags,
+            note: '',
+            spotify_url: null,
+            album_id: null,
+            status: 'pending',        // 自動publishは絶対禁止
+            content_type: contentType,
+            source: 'youtube_auto',
+            ingested_at: new Date().toISOString()
+          });
+
+          // カーソル更新候補
+          if (publishedAt) {
+            const pubDate = new Date(publishedAt);
+            if (!latestPublishedAt || pubDate > latestPublishedAt) {
+              latestPublishedAt = pubDate;
+            }
+          }
+        }
+
+        // (g) INSERT（status='pending', source='youtube_auto', ingested_at=now()）
+        let inserted = 0;
+        if (toInsert.length > 0) {
+          const insRes = await fetch(
+            `${SUPABASE_URL}/rest/v1/videos`,
+            {
+              method: 'POST',
+              headers: { ...sbHeaders, Prefer: 'return=minimal' },
+              body: JSON.stringify(toInsert)
+            }
+          );
+          if (insRes.ok) {
+            inserted = toInsert.length;
+          } else {
+            const errText = await insRes.text().catch(() => '');
+            throw new Error(`INSERT失敗: ${insRes.status} ${errText.slice(0, 200)}`);
+          }
+        }
+
+        // (h) カーソル更新（last_checked_at + last_video_published_at）
+        const cursorUpdate = { last_checked_at: new Date().toISOString() };
+        if (latestPublishedAt) {
+          cursorUpdate.last_video_published_at = latestPublishedAt instanceof Date
+            ? latestPublishedAt.toISOString()
+            : latestPublishedAt;
+        }
+        await fetch(
+          `${SUPABASE_URL}/rest/v1/ingest_channels?id=eq.${channel.id}`,
+          {
+            method: 'PATCH',
+            headers: sbHeaders,
+            body: JSON.stringify(cursorUpdate)
+          }
+        );
+
+        results.push({
+          channel_id: channel.channel_id,
+          member_id: channel.member_id,
+          new_items: newItems.length,
+          inserted,
+          skipped: newItems.length - toInsert.length - (toInsert.length - inserted)
+        });
+
+      } catch (channelErr) {
+        // チャンネル単位のエラー: カーソル据え置き（次回自動リトライ）
+        console.error(`チャンネル ${channel.channel_id} でエラー:`, channelErr);
+        results.push({ channel_id: channel.channel_id, error: channelErr.message });
+      }
+    }
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ ok: true, processed: channels.length, results })
+    };
+
+  } catch (e) {
+    console.error('ingest-youtube fatal error:', e);
+    return { statusCode: 500, body: JSON.stringify({ error: e.message }) };
+  }
+};

--- a/netlify/functions/ingest-youtube.js
+++ b/netlify/functions/ingest-youtube.js
@@ -8,8 +8,10 @@
 // ── キーワード定数辞書 ──
 const SHORTS_KEYWORDS = ['#shorts'];
 const LIVE_KEYWORDS = [
-  'ワンマン', 'ライブ映像', 'LIVE', '不可解', '現象', '狂想'
+  'ワンマン', 'ライブ映像', '不可解', '現象', '狂想'
 ];
+// 英語 "live" は部分一致だと "deliver"/"believe" 等を誤爆するため単語境界で判定
+const LIVE_WORD_RE = /\blive\b/i;
 const ANNOUNCEMENT_KEYWORDS = [
   '告知', 'トレーラー', 'Teaser', 'XFD', 'クロスフェード', '予告',
   '開催決定', '発売決定', '情報解禁'
@@ -54,9 +56,11 @@ function classifyContentType(title, description, durationSec, hasLiveDetails) {
   }
 
   // live: liveStreamingDetailsあり OR タイトルにライブ系キーワード
+  // 英語 "live" のみ単語境界一致（誤爆防止）、日本語キーワードは部分一致
   if (
     hasLiveDetails ||
-    LIVE_KEYWORDS.some(k => titleLower.includes(k.toLowerCase()))
+    LIVE_KEYWORDS.some(k => titleLower.includes(k.toLowerCase())) ||
+    LIVE_WORD_RE.test(title)
   ) {
     return 'live';
   }
@@ -118,13 +122,10 @@ exports.handler = async (event) => {
   }
 
   // ── 手動起動ガード ──
-  // Netlifyスケジュール実行: event.httpMethod が undefined または 'POST' で
-  // event.body に {"next_run":...} が含まれる。
-  // それ以外（HTTP直叩き）の場合は ADMIN_PASSWORD トークンを要求する。
-  const isScheduled = (
-    !event.httpMethod ||
-    (event.httpMethod === 'POST' && event.body && event.body.includes('next_run'))
-  );
+  // Netlifyスケジューラ起動のみ httpMethod が存在しない。
+  // HTTP経由（httpMethodあり）の呼び出しはすべて ADMIN_PASSWORD トークン必須。
+  // 本文スニッフィング（next_run等）による判定はバイパス可能なため行わない。
+  const isScheduled = !event.httpMethod;
 
   if (!isScheduled) {
     const authHeader = event.headers?.authorization || event.headers?.Authorization || '';

--- a/netlify/functions/observer-link-exchange.js
+++ b/netlify/functions/observer-link-exchange.js
@@ -31,6 +31,22 @@ async function sbFetch(url, options) {
   return res.json();
 }
 
+// videos取得専用: migration未適用で status 列が存在しない場合（PostgREST 42703）は
+// status=eq.published フィルタなしで1回だけ再試行する。
+// migration適用前は status 列が存在しない = pending 行も存在し得ないため、
+// フィルタなしは従来挙動そのもので安全。
+async function sbFetchVideos(url, options) {
+  const res = await fetch(url, options);
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    if (text.includes('42703') && url.includes('&status=eq.published')) {
+      return sbFetch(url.replace('&status=eq.published', ''), options);
+    }
+    throw new Error(`Supabase ${res.status}: ${text.slice(0, 200)}`);
+  }
+  return res.json();
+}
+
 exports.handler = async (event) => {
   if (event.httpMethod === 'OPTIONS') {
     return {
@@ -89,7 +105,7 @@ exports.handler = async (event) => {
     }
 
     // Validate video_id exists in videos table
-    const videoData = await sbFetch(
+    const videoData = await sbFetchVideos(
       `${url}/rest/v1/videos?select=id,title,member,date,url&id=eq.${numericVideoId}&status=eq.published`,
       { headers: { apikey: key, Authorization: `Bearer ${key}` } }
     );
@@ -153,7 +169,7 @@ exports.handler = async (event) => {
         );
 
         // Get matched video info
-        const matchedVideoData = await sbFetch(
+        const matchedVideoData = await sbFetchVideos(
           `${url}/rest/v1/videos?select=id,title,member,date,url&id=eq.${matched.video_id}&status=eq.published`,
           { headers: { apikey: key, Authorization: `Bearer ${key}` } }
         );
@@ -191,7 +207,7 @@ exports.handler = async (event) => {
     }
 
     // Fallback: no match available — recommend a random song
-    const fallbackData = await sbFetch(
+    const fallbackData = await sbFetchVideos(
       `${url}/rest/v1/videos?select=id,title,member,date,url&status=eq.published&limit=50`,
       { headers: { apikey: key, Authorization: `Bearer ${key}` } }
     );

--- a/netlify/functions/observer-link-exchange.js
+++ b/netlify/functions/observer-link-exchange.js
@@ -90,7 +90,7 @@ exports.handler = async (event) => {
 
     // Validate video_id exists in videos table
     const videoData = await sbFetch(
-      `${url}/rest/v1/videos?select=id,title,member,date,url&id=eq.${numericVideoId}`,
+      `${url}/rest/v1/videos?select=id,title,member,date,url&id=eq.${numericVideoId}&status=eq.published`,
       { headers: { apikey: key, Authorization: `Bearer ${key}` } }
     );
     if (!Array.isArray(videoData) || videoData.length === 0) {
@@ -154,7 +154,7 @@ exports.handler = async (event) => {
 
         // Get matched video info
         const matchedVideoData = await sbFetch(
-          `${url}/rest/v1/videos?select=id,title,member,date,url&id=eq.${matched.video_id}`,
+          `${url}/rest/v1/videos?select=id,title,member,date,url&id=eq.${matched.video_id}&status=eq.published`,
           { headers: { apikey: key, Authorization: `Bearer ${key}` } }
         );
         const receivedVideo = (Array.isArray(matchedVideoData) && matchedVideoData.length > 0) ? matchedVideoData[0] : null;
@@ -192,7 +192,7 @@ exports.handler = async (event) => {
 
     // Fallback: no match available — recommend a random song
     const fallbackData = await sbFetch(
-      `${url}/rest/v1/videos?select=id,title,member,date,url&limit=50`,
+      `${url}/rest/v1/videos?select=id,title,member,date,url&status=eq.published&limit=50`,
       { headers: { apikey: key, Authorization: `Bearer ${key}` } }
     );
     const pool = Array.isArray(fallbackData) ? fallbackData.filter(v => v.id !== numericVideoId) : [];

--- a/netlify/functions/observer-link-result.js
+++ b/netlify/functions/observer-link-result.js
@@ -31,7 +31,7 @@ exports.handler = async (event) => {
 
     // Get sent video info
     const sentVideoRes = await fetch(
-      `${url}/rest/v1/videos?select=id,title,member,date,url&id=eq.${bottle.video_id}`,
+      `${url}/rest/v1/videos?select=id,title,member,date,url&id=eq.${bottle.video_id}&status=eq.published`,
       { headers: sbHeaders }
     );
     const sentVideos = await sentVideoRes.json();
@@ -49,7 +49,7 @@ exports.handler = async (event) => {
       if (Array.isArray(matchedBottles) && matchedBottles.length > 0) {
         receivedBottle = matchedBottles[0];
         const recVideoRes = await fetch(
-          `${url}/rest/v1/videos?select=id,title,member,date,url&id=eq.${receivedBottle.video_id}`,
+          `${url}/rest/v1/videos?select=id,title,member,date,url&id=eq.${receivedBottle.video_id}&status=eq.published`,
           { headers: sbHeaders }
         );
         const recVideos = await recVideoRes.json();
@@ -60,7 +60,7 @@ exports.handler = async (event) => {
     // Handle fallback recommendations
     if (bottle.status === 'fallback_matched' && bottle.fallback_video_id) {
       const fbVideoRes = await fetch(
-        `${url}/rest/v1/videos?select=id,title,member,date,url&id=eq.${bottle.fallback_video_id}`,
+        `${url}/rest/v1/videos?select=id,title,member,date,url&id=eq.${bottle.fallback_video_id}&status=eq.published`,
         { headers: sbHeaders }
       );
       const fbVideos = await fbVideoRes.json();

--- a/netlify/functions/observer-link-result.js
+++ b/netlify/functions/observer-link-result.js
@@ -1,3 +1,18 @@
+// videos取得専用: migration未適用で status 列が存在しない場合（PostgREST 42703）は
+// status=eq.published フィルタなしで1回だけ再試行する。
+// migration適用前は status 列が存在しない = pending 行も存在し得ないため、
+// フィルタなしは従来挙動そのもので安全。
+// 戻り値はパース済みJSON（失敗時は null）。呼び出し側は Array.isArray でチェックする。
+async function fetchVideoRows(url, headers) {
+  let res = await fetch(url, { headers });
+  let body = await res.text().catch(() => '');
+  if (!res.ok && body.includes('42703') && url.includes('&status=eq.published')) {
+    res = await fetch(url.replace('&status=eq.published', ''), { headers });
+    body = await res.text().catch(() => '');
+  }
+  try { return JSON.parse(body); } catch (e) { return null; }
+}
+
 exports.handler = async (event) => {
   const siteUrl = 'https://vwp-archive.netlify.app';
 
@@ -30,11 +45,10 @@ exports.handler = async (event) => {
     const bottle = bottles[0];
 
     // Get sent video info
-    const sentVideoRes = await fetch(
+    const sentVideos = await fetchVideoRows(
       `${url}/rest/v1/videos?select=id,title,member,date,url&id=eq.${bottle.video_id}&status=eq.published`,
-      { headers: sbHeaders }
+      sbHeaders
     );
-    const sentVideos = await sentVideoRes.json();
     const sentVideo = Array.isArray(sentVideos) && sentVideos.length > 0 ? sentVideos[0] : null;
 
     // Get received video info (from matched_with)
@@ -48,22 +62,20 @@ exports.handler = async (event) => {
       const matchedBottles = await matchedRes.json();
       if (Array.isArray(matchedBottles) && matchedBottles.length > 0) {
         receivedBottle = matchedBottles[0];
-        const recVideoRes = await fetch(
+        const recVideos = await fetchVideoRows(
           `${url}/rest/v1/videos?select=id,title,member,date,url&id=eq.${receivedBottle.video_id}&status=eq.published`,
-          { headers: sbHeaders }
+          sbHeaders
         );
-        const recVideos = await recVideoRes.json();
         receivedVideo = Array.isArray(recVideos) && recVideos.length > 0 ? recVideos[0] : null;
       }
     }
 
     // Handle fallback recommendations
     if (bottle.status === 'fallback_matched' && bottle.fallback_video_id) {
-      const fbVideoRes = await fetch(
+      const fbVideos = await fetchVideoRows(
         `${url}/rest/v1/videos?select=id,title,member,date,url&id=eq.${bottle.fallback_video_id}&status=eq.published`,
-        { headers: sbHeaders }
+        sbHeaders
       );
-      const fbVideos = await fbVideoRes.json();
       const fbVideo = Array.isArray(fbVideos) && fbVideos.length > 0 ? fbVideos[0] : null;
       if (fbVideo) {
         return fallbackResultPage(siteUrl, id, sentVideo, bottle, fbVideo);

--- a/netlify/functions/videos-get.js
+++ b/netlify/functions/videos-get.js
@@ -10,7 +10,7 @@ exports.handler = async () => {
     const pageSize = 1000;
     while (true) {
       const res = await fetch(
-        `${url}/rest/v1/videos?select=*&order=date.desc&limit=${pageSize}&offset=${offset}`,
+        `${url}/rest/v1/videos?select=*&status=eq.published&order=date.desc&limit=${pageSize}&offset=${offset}`,
         { headers }
       );
       const data = await res.json();

--- a/netlify/functions/videos-get.js
+++ b/netlify/functions/videos-get.js
@@ -4,17 +4,39 @@ exports.handler = async () => {
   // フォールバック: SUPABASE_ANON_KEY 未設定時は SECRET_KEY を使用
   const key = process.env.SUPABASE_ANON_KEY || process.env.SUPABASE_SECRET_KEY;
   const headers = { apikey: key, Authorization: `Bearer ${key}` };
+
+  // 1ページ取得。migration未適用で status 列が存在しない場合（PostgREST 42703）は
+  // status=eq.published フィルタなしで1回だけ再試行する。
+  // migration適用前は status 列が存在しない = pending 行も存在し得ないため、
+  // フィルタなしは従来挙動そのもので安全。
+  async function fetchPage(pageUrl) {
+    let res = await fetch(pageUrl, { headers });
+    if (!res.ok) {
+      const errText = await res.text().catch(() => '');
+      if (errText.includes('42703') && pageUrl.includes('&status=eq.published')) {
+        res = await fetch(pageUrl.replace('&status=eq.published', ''), { headers });
+      }
+      if (!res.ok) {
+        const text = await res.text().catch(() => errText);
+        throw new Error(`Supabase ${res.status}: ${(text || errText).slice(0, 200)}`);
+      }
+    }
+    const data = await res.json();
+    if (!Array.isArray(data)) {
+      throw new Error('Supabase returned non-array response');
+    }
+    return data;
+  }
+
   try {
     let all = [];
     let offset = 0;
     const pageSize = 1000;
     while (true) {
-      const res = await fetch(
-        `${url}/rest/v1/videos?select=*&status=eq.published&order=date.desc&limit=${pageSize}&offset=${offset}`,
-        { headers }
+      const data = await fetchPage(
+        `${url}/rest/v1/videos?select=*&status=eq.published&order=date.desc&limit=${pageSize}&offset=${offset}`
       );
-      const data = await res.json();
-      if (!Array.isArray(data) || data.length === 0) break;
+      if (data.length === 0) break;
       all = all.concat(data);
       if (data.length < pageSize) break;
       offset += pageSize;
@@ -29,6 +51,11 @@ exports.handler = async () => {
       body: JSON.stringify(all),
     };
   } catch (e) {
-    return { statusCode: 500, body: JSON.stringify({ error: e.message }) };
+    // エラー・非配列レスポンスをキャッシュ可能な200空配列で返さない（CDN焼き付き防止）
+    return {
+      statusCode: 500,
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+      body: JSON.stringify({ error: e.message }),
+    };
   }
 };

--- a/public/admin.css
+++ b/public/admin.css
@@ -439,3 +439,69 @@ canvas#grid-bg { position: absolute; inset: 0; z-index: 0; }
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { animation: none !important; transition-duration: .01ms !important; }
 }
+
+/* ═══ LAYER 9 — INCOMING TRANSMISSION Tab ═══ */
+
+/* サブタブ */
+.ic-subtabs {
+  display: flex; gap: 4px; margin-bottom: 12px; flex-wrap: wrap;
+}
+.ic-subtab {
+  font-family: var(--f); font-size: 10px; letter-spacing: 1px; padding: 4px 12px;
+  border: 1px solid var(--border-dim); background: none;
+  color: var(--text-dim); cursor: pointer; text-transform: uppercase;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.ic-subtab:hover { color: var(--phosphor); border-color: var(--border); }
+.ic-subtab.active {
+  color: var(--phosphor); border-color: var(--phosphor);
+  background: var(--phosphor-08);
+}
+
+/* バルク操作バー */
+.ic-bulk-bar {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 8px 0; margin-bottom: 8px; gap: 12px; flex-wrap: wrap;
+}
+.ic-check-label {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 10px; letter-spacing: 1px; color: var(--text-dim); cursor: pointer;
+}
+.ic-check-label input[type="checkbox"] { accent-color: var(--phosphor); width: 13px; height: 13px; }
+
+/* テーブル */
+.ic-table { table-layout: fixed; }
+.ic-table td:nth-child(1) { width: 28px; }
+.ic-table td:nth-child(2) { width: 56px; }
+.ic-table td:nth-child(3) { width: auto; }
+.ic-table td:nth-child(4) { width: 110px; }
+.ic-table td:nth-child(5) { width: 80px; }
+.ic-table td:nth-child(6) { width: 110px; }
+.ic-table td:nth-child(7) { width: 120px; }
+.ic-table td:nth-child(8) { width: 200px; }
+
+/* サムネ */
+.ic-thumb-cell { padding: 4px 6px !important; }
+.ic-thumb {
+  width: 48px; height: 36px; object-fit: cover; display: block;
+  border: 1px solid var(--border-dim);
+}
+
+/* タイトル */
+.ic-title {
+  font-size: 10px !important; word-break: break-all; line-height: 1.4;
+  max-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+
+/* インライン編集インプット */
+.ic-table .n-input-sm, .ic-table .n-select {
+  font-size: 10px; padding: 2px 5px; width: 100%;
+  text-transform: none;
+}
+.ic-table .n-select { font-size: 10px; padding: 2px 4px; }
+
+@media (max-width: 768px) {
+  .ic-subtabs { gap: 2px; }
+  .ic-table td:nth-child(2),
+  .ic-table td:nth-child(7) { display: none; }
+}

--- a/public/admin.html
+++ b/public/admin.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>MU-TH-UR 6000 — V.W.P ARCHIVE</title>
 <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="admin.css?v=6">
+<link rel="stylesheet" href="admin.css?v=7">
 </head>
 <body>
 <div class="crt-wrap">
@@ -52,6 +52,6 @@
 
 <div id="modal-root"></div>
 
-<script src="admin.js?v=8"></script>
+<script src="admin.js?v=9"></script>
 </body>
 </html>

--- a/public/admin.html
+++ b/public/admin.html
@@ -52,6 +52,6 @@
 
 <div id="modal-root"></div>
 
-<script src="admin.js?v=9"></script>
+<script src="admin.js?v=10"></script>
 </body>
 </html>

--- a/public/admin.js
+++ b/public/admin.js
@@ -226,6 +226,262 @@ MU.Modal = {
 };
 
 /* ═══════════════════════════════════════
+ *   TAB: INCOMING TRANSMISSION
+ * ═══════════════════════════════════════ */
+MU.Tabs.register('incoming', {
+  label: 'INCOMING TRANSMISSION', order: 5,
+  render: async function(el) {
+    var U = MU.UI;
+    var CONTENT_TYPES = ['all', 'song', 'live', 'shorts', 'announcement'];
+    try {
+      var pending = await MU.DB.query('videos', {
+        select: 'id,title,member,date,url,tags,content_type,status,ingested_at,source',
+        filter: 'status=eq.pending',
+        order: 'ingested_at.desc.nullslast',
+        limit: '9999'
+      });
+
+      // タブボタンのバッジを件数で更新
+      var tabBtn = document.querySelector('.tab-btn[data-tab="incoming"]');
+      if (tabBtn) {
+        tabBtn.textContent = 'INCOMING TRANSMISSION' + (pending.length > 0 ? ' [' + pending.length + ']' : '');
+      }
+
+      var state = { videos: pending, activeType: 'all', selected: new Set() };
+
+      function getFiltered() {
+        if (state.activeType === 'all') return state.videos.slice();
+        return state.videos.filter(function(v) { return v.content_type === state.activeType; });
+      }
+
+      function countByType(type) {
+        if (type === 'all') return state.videos.length;
+        return state.videos.filter(function(v) { return v.content_type === type; }).length;
+      }
+
+      function renderSubTabs() {
+        return '<div class="ic-subtabs">' +
+          CONTENT_TYPES.map(function(t) {
+            var cnt = countByType(t);
+            var cls = 'ic-subtab' + (state.activeType === t ? ' active' : '');
+            return '<button class="' + cls + '" data-type="' + t + '">' +
+              t.toUpperCase() +
+              (cnt > 0 ? ' <span class="n-badge">' + cnt + '</span>' : '') +
+              '</button>';
+          }).join('') +
+          '</div>';
+      }
+
+      function renderTable() {
+        var filtered = getFiltered();
+        if (filtered.length === 0) {
+          return '<div class="n-note" style="margin-top:16px">QUEUE EMPTY — NO PENDING RECORDS</div>';
+        }
+        var allChecked = filtered.length > 0 && filtered.every(function(v) { return state.selected.has(v.id); });
+        var html =
+          '<div class="ic-bulk-bar">' +
+          '<label class="ic-check-label"><input type="checkbox" id="ic-select-all"' + (allChecked ? ' checked' : '') + '> SELECT ALL (' + filtered.length + ')</label>' +
+          '<div class="n-btn-group">' +
+          '<button class="n-btn ic-bulk-publish" ' + (state.selected.size === 0 ? 'disabled' : '') + '>PUBLISH SELECTED (' + state.selected.size + ')</button>' +
+          '<button class="n-btn n-btn-red ic-bulk-reject" ' + (state.selected.size === 0 ? 'disabled' : '') + '>REJECT SELECTED</button>' +
+          '</div></div>' +
+          '<table class="n-table ic-table"><thead><tr>' +
+          '<th></th><th>THUMB</th><th>TITLE</th><th>MEMBER</th><th>DATE</th><th>TYPE</th><th>TAGS</th><th></th>' +
+          '</tr></thead><tbody>' +
+          filtered.map(function(v) {
+            var ytId = (v.url || '').match(/(?:v=|youtu\.be\/)([^&?#]+)/);
+            ytId = ytId ? ytId[1] : '';
+            var thumb = ytId ? 'https://img.youtube.com/vi/' + ytId + '/default.jpg' : '';
+            var mc = memberColor(v.member);
+            var chk = state.selected.has(v.id) ? ' checked' : '';
+            return '<tr data-id="' + v.id + '">' +
+              '<td><input type="checkbox" class="ic-row-chk"' + chk + ' data-id="' + v.id + '"></td>' +
+              '<td class="ic-thumb-cell">' + (thumb ? '<img src="' + esc(thumb) + '" alt="" class="ic-thumb" loading="lazy">' : '—') + '</td>' +
+              '<td class="title-col ic-title">' + esc(v.title || '—') + '</td>' +
+              '<td>' +
+                '<input class="n-input n-input-sm ic-edit-member" data-id="' + v.id + '" value="' + esc(v.member || '') + '" title="MEMBER">' +
+              '</td>' +
+              '<td class="mono">' + fmtDate(v.date) + '</td>' +
+              '<td>' +
+                '<select class="n-select ic-edit-type" data-id="' + v.id + '">' +
+                ['song', 'live', 'shorts', 'announcement'].map(function(t) {
+                  return '<option value="' + t + '"' + (v.content_type === t ? ' selected' : '') + '>' + t.toUpperCase() + '</option>';
+                }).join('') +
+                '</select>' +
+              '</td>' +
+              '<td>' +
+                '<input class="n-input n-input-sm ic-edit-tags" data-id="' + v.id + '" value="' + esc(v.tags || '') + '" title="TAGS">' +
+              '</td>' +
+              '<td class="r"><div class="n-btn-group">' +
+                '<button class="n-btn n-btn-sm ic-save" data-id="' + v.id + '">SAVE</button>' +
+                '<button class="n-btn n-btn-sm ic-publish" data-id="' + v.id + '">PUBLISH</button>' +
+                '<button class="n-btn n-btn-sm n-btn-red ic-reject" data-id="' + v.id + '">REJECT</button>' +
+              '</div></td></tr>';
+          }).join('') +
+          '</tbody></table>';
+        return html;
+      }
+
+      function fullRender() {
+        el.innerHTML =
+          '<div class="n-section">' + U.section('INCOMING TRANSMISSION', U.badge(pending.length + ' PENDING', pending.length > 0 ? 'warn' : '')) +
+          renderSubTabs() +
+          '<div id="ic-table-wrap">' + renderTable() + '</div>' +
+          '</div>';
+        MU.Decode.decodeAll(el);
+        bindEvents();
+      }
+
+      function bindEvents() {
+        // サブタブ切替
+        el.querySelectorAll('.ic-subtab').forEach(function(btn) {
+          btn.addEventListener('click', function() {
+            state.activeType = btn.dataset.type;
+            state.selected.clear();
+            document.getElementById('ic-table-wrap').innerHTML = renderTable();
+            el.querySelectorAll('.ic-subtab').forEach(function(b) {
+              b.classList.toggle('active', b.dataset.type === state.activeType);
+            });
+            rebindTableEvents();
+          });
+        });
+        rebindTableEvents();
+      }
+
+      function rebindTableEvents() {
+        // SELECT ALL
+        var selectAll = document.getElementById('ic-select-all');
+        if (selectAll) {
+          selectAll.addEventListener('change', function() {
+            var filtered = getFiltered();
+            if (selectAll.checked) { filtered.forEach(function(v) { state.selected.add(v.id); }); }
+            else { state.selected.clear(); }
+            document.getElementById('ic-table-wrap').innerHTML = renderTable();
+            rebindTableEvents();
+          });
+        }
+
+        // 行チェックボックス
+        el.querySelectorAll('.ic-row-chk').forEach(function(chk) {
+          chk.addEventListener('change', function() {
+            var id = parseInt(chk.dataset.id, 10);
+            if (chk.checked) state.selected.add(id);
+            else state.selected.delete(id);
+            // バルクバーの件数だけ更新
+            var bulkPublish = document.querySelector('.ic-bulk-publish');
+            var bulkReject = document.querySelector('.ic-bulk-reject');
+            if (bulkPublish) {
+              bulkPublish.textContent = 'PUBLISH SELECTED (' + state.selected.size + ')';
+              bulkPublish.disabled = state.selected.size === 0;
+            }
+            if (bulkReject) bulkReject.disabled = state.selected.size === 0;
+          });
+        });
+
+        // SAVE（member + tags + content_type の一括保存）
+        el.querySelectorAll('.ic-save').forEach(function(btn) {
+          btn.addEventListener('click', async function() {
+            var id = btn.dataset.id;
+            var row = btn.closest('tr');
+            var memberVal = row.querySelector('.ic-edit-member').value.trim();
+            var tagsVal = row.querySelector('.ic-edit-tags').value.trim();
+            var typeVal = row.querySelector('.ic-edit-type').value;
+            try {
+              await MU.DB.update('videos', id, { member: memberVal, tags: tagsVal, content_type: typeVal });
+              // ローカル状態も更新
+              var v = state.videos.find(function(x) { return String(x.id) === String(id); });
+              if (v) { v.member = memberVal; v.tags = tagsVal; v.content_type = typeVal; }
+              btn.textContent = 'SAVED'; btn.disabled = true;
+              setTimeout(function() { btn.textContent = 'SAVE'; btn.disabled = false; }, 1500);
+            } catch (e) { alert('SAVE FAILED: ' + e.message); }
+          });
+        });
+
+        // PUBLISH 単体
+        el.querySelectorAll('.ic-publish').forEach(function(btn) {
+          btn.addEventListener('click', async function() {
+            var id = btn.dataset.id;
+            if (!confirm('PUBLISH RECORD #' + id + '?')) return;
+            try {
+              await MU.DB.update('videos', id, { status: 'published' });
+              state.videos = state.videos.filter(function(v) { return String(v.id) !== String(id); });
+              state.selected.delete(parseInt(id, 10));
+              document.getElementById('ic-table-wrap').innerHTML = renderTable();
+              rebindTableEvents();
+              updateBadge();
+            } catch (e) { alert('PUBLISH FAILED: ' + e.message); }
+          });
+        });
+
+        // REJECT 単体
+        el.querySelectorAll('.ic-reject').forEach(function(btn) {
+          btn.addEventListener('click', async function() {
+            var id = btn.dataset.id;
+            if (!confirm('REJECT RECORD #' + id + '?')) return;
+            try {
+              await MU.DB.update('videos', id, { status: 'rejected' });
+              state.videos = state.videos.filter(function(v) { return String(v.id) !== String(id); });
+              state.selected.delete(parseInt(id, 10));
+              document.getElementById('ic-table-wrap').innerHTML = renderTable();
+              rebindTableEvents();
+              updateBadge();
+            } catch (e) { alert('REJECT FAILED: ' + e.message); }
+          });
+        });
+
+        // PUBLISH 一括
+        var bulkPublishBtn = el.querySelector('.ic-bulk-publish');
+        if (bulkPublishBtn) {
+          bulkPublishBtn.addEventListener('click', async function() {
+            var ids = Array.from(state.selected);
+            if (ids.length === 0) return;
+            if (!confirm('PUBLISH ' + ids.length + ' RECORDS?')) return;
+            try {
+              await Promise.all(ids.map(function(id) { return MU.DB.update('videos', id, { status: 'published' }); }));
+              state.videos = state.videos.filter(function(v) { return !state.selected.has(v.id); });
+              state.selected.clear();
+              document.getElementById('ic-table-wrap').innerHTML = renderTable();
+              rebindTableEvents();
+              updateBadge();
+            } catch (e) { alert('BULK PUBLISH FAILED: ' + e.message); }
+          });
+        }
+
+        // REJECT 一括
+        var bulkRejectBtn = el.querySelector('.ic-bulk-reject');
+        if (bulkRejectBtn) {
+          bulkRejectBtn.addEventListener('click', async function() {
+            var ids = Array.from(state.selected);
+            if (ids.length === 0) return;
+            if (!confirm('REJECT ' + ids.length + ' RECORDS?')) return;
+            try {
+              await Promise.all(ids.map(function(id) { return MU.DB.update('videos', id, { status: 'rejected' }); }));
+              state.videos = state.videos.filter(function(v) { return !state.selected.has(v.id); });
+              state.selected.clear();
+              document.getElementById('ic-table-wrap').innerHTML = renderTable();
+              rebindTableEvents();
+              updateBadge();
+            } catch (e) { alert('BULK REJECT FAILED: ' + e.message); }
+          });
+        }
+      }
+
+      function updateBadge() {
+        var tabBtn = document.querySelector('.tab-btn[data-tab="incoming"]');
+        if (tabBtn) {
+          tabBtn.textContent = 'INCOMING TRANSMISSION' + (state.videos.length > 0 ? ' [' + state.videos.length + ']' : '');
+        }
+      }
+
+      fullRender();
+
+    } catch (e) {
+      el.innerHTML = U.alert('SYSTEM ERROR: ' + esc(e.message));
+    }
+  }
+});
+
+/* ═══════════════════════════════════════
  *   TAB: SONGS DATABASE
  * ═══════════════════════════════════════ */
 MU.Tabs.register('songs', {

--- a/public/admin.js
+++ b/public/admin.js
@@ -490,11 +490,12 @@ MU.Tabs.register('songs', {
     try {
       // Fetch data
       var results = await Promise.all([
-        MU.DB.query('videos', { select: 'id', limit: '9999' }),
-        MU.DB.query('videos', { select: 'id', filter: 'album_id=is.null', limit: '9999' }),
+        MU.DB.query('videos', { select: 'id', filter: 'status=eq.published', limit: '9999' }),
+        MU.DB.query('videos', { select: 'id', filter: 'album_id=is.null&status=eq.published', limit: '9999' }),
         MU.DB.query('albums', { select: 'id,name', limit: '999' }),
         MU.DB.query('videos', {
           select: 'id,title,member,date,url,tags,note,spotify_url,album_id',
+          filter: 'status=eq.published',
           order: 'date.desc.nullslast', limit: '9999'
         })
       ]);
@@ -871,7 +872,7 @@ MU.Tabs.register('ol', {
           select: 'id,status,video_id,matched_with,fallback_video_id,created_at,client_hash,message',
           order: 'created_at.desc', limit: '50'
         }),
-        MU.DB.query('videos', { select: 'id,title,member', limit: '9999' })
+        MU.DB.query('videos', { select: 'id,title,member', filter: 'status=eq.published', limit: '9999' })
       ]);
       var allBottles = results[0];
       var recentBottles = results[1];

--- a/public/admin.js
+++ b/public/admin.js
@@ -292,7 +292,6 @@ MU.Tabs.register('incoming', {
             var ytId = (v.url || '').match(/(?:v=|youtu\.be\/)([^&?#]+)/);
             ytId = ytId ? ytId[1] : '';
             var thumb = ytId ? 'https://img.youtube.com/vi/' + ytId + '/default.jpg' : '';
-            var mc = memberColor(v.member);
             var chk = state.selected.has(v.id) ? ' checked' : '';
             return '<tr data-id="' + v.id + '">' +
               '<td><input type="checkbox" class="ic-row-chk"' + chk + ' data-id="' + v.id + '"></td>' +

--- a/supabase/migrations/20260707000000_youtube_auto_ingest.sql
+++ b/supabase/migrations/20260707000000_youtube_auto_ingest.sql
@@ -1,0 +1,40 @@
+-- ═══════════════════════════════════════════════════════════════
+-- Migration: youtube_auto_ingest
+-- 2026-07-07
+-- ═══════════════════════════════════════════════════════════════
+
+-- ── videos テーブルに新4列を追加 ──
+
+ALTER TABLE videos
+  ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'published'
+    CHECK (status IN ('published', 'pending', 'rejected'));
+
+ALTER TABLE videos
+  ADD COLUMN IF NOT EXISTS content_type TEXT NOT NULL DEFAULT 'song'
+    CHECK (content_type IN ('song', 'live', 'shorts', 'announcement'));
+
+ALTER TABLE videos
+  ADD COLUMN IF NOT EXISTS source TEXT DEFAULT 'manual';
+
+ALTER TABLE videos
+  ADD COLUMN IF NOT EXISTS ingested_at TIMESTAMPTZ;
+
+-- ── インデックス ──
+
+CREATE INDEX IF NOT EXISTS idx_videos_status
+  ON videos (status);
+
+CREATE INDEX IF NOT EXISTS idx_videos_content_type
+  ON videos (content_type);
+
+-- ── ingest_channels テーブル新規作成 ──
+
+CREATE TABLE IF NOT EXISTS ingest_channels (
+  id                      SERIAL PRIMARY KEY,
+  member_id               TEXT NOT NULL,
+  channel_id              TEXT NOT NULL UNIQUE,
+  uploads_playlist_id     TEXT,
+  enabled                 BOOLEAN DEFAULT true,
+  last_checked_at         TIMESTAMPTZ,
+  last_video_published_at TIMESTAMPTZ
+);


### PR DESCRIPTION
## 目的
YouTube自動取り込みパイプラインの導入。登録チャンネルの新着動画を6時間ごとに取得し、`status='pending'` でDBに投入。人間がadminの「INCOMING TRANSMISSION」タブから公開/却下を判断する。自動publishは行わない（憲法10準拠）。

あわせて、status列導入に伴う公開経路・admin集計のフィルタ整備を実施。

## 変更したもの
- **新Function `netlify/functions/ingest-youtube.js`（359行）** — `ingest_channels` の各チャンネルの uploads playlist を辿り、カーソル（`last_video_published_at`）以降の新着動画を `videos.list` で詳細取得 → `status:'pending'` でINSERT。手動起動は `ADMIN_PASSWORD` Bearer必須。
- **`netlify.toml`** — `[functions."ingest-youtube"]` に `schedule = "0 */6 * * *"`（4回/日）を追加。
- **migration `20260707000000_youtube_auto_ingest.sql`** — `videos` に4列追加（`status`/`content_type`/`source`/`ingested_at`、いずれも `ADD COLUMN IF NOT EXISTS`、`status` DEFAULT `'published'`）+ `ingest_channels` テーブル新設。破壊的変更なし・冪等。
- **`videos-get.js`** — 公開取得クエリに `status=eq.published` を明記（憲法2）。migration未適用時の 42703 フォールバック付き。
- **`observer-link-exchange.js` / `observer-link-result.js`** — video取得3箇所に `status=eq.published` を追加（PR前はフィルタ無し=改善）。42703フォールバック付き。matching/status遷移/fallback永続化ロジックは無改変。
- **`admin.js` / `admin.html` / `admin.css`** — INCOMING TRANSMISSIONタブ（`status=eq.pending` 表示、PUBLISH/REJECT/バルク操作）を追加。SONGS DATABASE系4クエリに `status=eq.published` を追加（回帰 M1 対応）。`admin.js?v=10` にキャッシュバスティング更新。
- **`docs/VWP_ARCHIVE_unified_spec.md`** — videosスキーマ節に新4列 + ingest_channels を追記。

## 変更していないもの（保証事項）
- 公開サイトのvideos取得は `/api/videos-get` 経由のみで、サーバ側 `status=eq.published` が効く。pending/rejectedの公開漏洩なし（憲法2）。
- 自動publishなし。ingestのINSERTは `status:'pending'` 固定、videosへのPATCHなし（憲法10）。
- `song_bottles.status`（waiting/matched/fallback_matched）と `guard_waiting_pool` トリガー、exchangeのフォールバック永続化ロジックは無改変（憲法6）。
- localStorageキー（`vwp_shelf`/`vwp_received`）・CSSスコープ（`shelf-`/`shelf-rcv-`/`ol-`）・windowに露出する関数/変数に一切触れていない（憲法3/4/8）。
- `netlify.toml` の `/result/` `force=true` は無傷（憲法7）。
- admin INCOMINGタブの `status=eq.pending` フィルタは変更なし。

## レビュー往復履歴（reviewerの指摘と対応）
reviewer判定: **APPROVE**（CRITICAL/HIGH ゼロ、憲法10箇条の違反なし）。指摘MEDIUM 3件:
- **M1（回帰）** admin SONGSタブ/件数メトリクスにpending・rejectedが混入 → **本PRで修正**（admin.js 4クエリに `status=eq.published` 追加、commit `5ffe138`）。verifierで再確認済み。
- **M2** 既存曲の重複突合がURL完全一致依存で、`youtu.be/` 形式等の既登録曲を誤って重複pending生成し得る → **判断保留（別PR追随可）**。
- **M3** YouTubeが詳細を返さない動画をカーソルが恒久スキップし、特定タイミングの曲が欠落し得る → **判断保留（別PR追随可）**。

## 動作確認方法（Yuki向け手順）
**前提**: migration適用 → その後デプロイの順で行う（逆順だとschema cache遅延で一時的な露出窓の恐れ）。

1. **Migration適用** — Supabase SQL Editorで `20260707000000_youtube_auto_ingest.sql` を実行。`videos` に4列 + `ingest_channels` テーブルができること。既存公開曲のstatusが `published` であること。
2. **公開サイトのpending漏れ確認** — `PREVIEW/` で DevTools > Network > `/api/videos-get` レスポンスの各行に `status:"pending"`/`"rejected"` が無い（全て `published`）こと。
3. **公開3ビュー/MY SHELF/OL** — ALL/メンバー/アルバム表示、+ボタンで `vwp_shelf` 追加削除、OLでボトル送信→ `/result/?id=xxx` 表示。
4. **admin INCOMING** — `PREVIEW/admin` ログイン → INCOMINGタブ表示（チャンネル未登録なら0件が正常）。手動実行: `curl -X POST https://PREVIEW/.netlify/functions/ingest-youtube -H "Authorization: Bearer <ADMIN_PASSWORD>"`。pending動画があればPUBLISHで公開・SONGS総数+1、REJECTで公開サイト非表示。
5. **モバイル** — DevTools iPhone 12 Proでウェルカム→カード→シェルフ動線。

verifier結果: JS構文 `node --check` 全PASS / 憲法2・10充足を静的確認 / migration破壊的変更なし。netlify dev動的確認はCLI未導入のためSKIP。

## 判断保留リスト
- **M2（URL完全一致dedup）** — videoId正規化での突合に改める別PRが必要か。放置すると `youtu.be/` 等の既登録曲が6時間ごとに重複pending化し蓄積する。
- **M3（カーソルスキップ）** — カーソルを取り込み可否と分離し `newItems` 全体の最大publishedAtで進める設計に改めるか。プレミア公開直後等の曲が静かに欠落し得る。
- **L1（deploy順序）** — ingestのINSERTには42703フォールバックが無い。migration未適用でスケジュール発火すると500（データ破損なし・安全側）。上記「前提」の順序を守れば回避。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
