### PR TITLE
fix(ingest): 重複突合のvideoId正規化 + カーソル恒久スキップ防止（PR #110 追随・M2/M3）

### DIFF
--- a/netlify/functions/ingest-youtube.js
+++ b/netlify/functions/ingest-youtube.js
@@ -162,6 +162,21 @@ exports.handler = async (event) => {
       return { statusCode: 200, body: JSON.stringify({ message: '有効なチャンネルがありません', results }) };
     }
 
+    // (e) Supabase で既存videoId突合（チャンネル横断・ループ外で1回だけfetch）
+    // pending含む全件 — status不問でないと重複取りこぼし
+    // 憲法5: 1,000件超は limit=10000&offset=0 を明示（デフォルトLIMIT 1000でsilent drop）
+    const existingRows = await sbFetch(
+      `${SUPABASE_URL}/rest/v1/videos?select=url&limit=10000&offset=0`,
+      { headers: { apikey: SUPABASE_KEY, Authorization: `Bearer ${SUPABASE_KEY}` } }
+    );
+    if (Array.isArray(existingRows) && existingRows.length >= 10000) {
+      console.error('videos件数が全件fetch上限(10000)に到達。dedup不完全のため取り込み中止。ページング実装が必要。');
+      return { statusCode: 500, body: JSON.stringify({ error: 'videos件数が上限に到達。ページング未実装のため安全のため中止。', count: existingRows.length }) };
+    }
+    const existingVideoIds = new Set(
+      (Array.isArray(existingRows) ? existingRows : []).map(r => ytId(r.url)).filter(Boolean)
+    );
+
     for (const channel of channels) {
       try {
         let uploadsPlaylistId = channel.uploads_playlist_id;
@@ -236,16 +251,6 @@ exports.handler = async (event) => {
         const videoDetails = {};
         (vtData.items || []).forEach(v => { videoDetails[v.id] = v; });
 
-        // (e) Supabase で既存videoId突合（pending含む全件 — status不問でないと重複取りこぼし）
-        // 憲法5: 1,000件超は limit=10000&offset=0 を明示（デフォルトLIMIT 1000でsilent drop）
-        const existingRows = await sbFetch(
-          `${SUPABASE_URL}/rest/v1/videos?select=url&limit=10000&offset=0`,
-          { headers: { apikey: SUPABASE_KEY, Authorization: `Bearer ${SUPABASE_KEY}` } }
-        );
-        const existingVideoIds = new Set(
-          (Array.isArray(existingRows) ? existingRows : []).map(r => ytId(r.url)).filter(Boolean)
-        );
-
         // playlistPubマップ: videoId → playlistItemのpublishedAt（詳細未取得時の公開日フォールバック用）
         const playlistPubMap = {};
         for (const item of newItems) {
@@ -270,6 +275,7 @@ exports.handler = async (event) => {
 
           if (!detail) {
             // details未取得（削除/非公開/プレミア処理中等）
+            if (existingVideoIds.has(videoId)) { existingCount++; continue; } // 既存はカーソル保護不要
             if (playlistPub) missingPubs.push(playlistPub);
             continue;
           }

--- a/netlify/functions/ingest-youtube.js
+++ b/netlify/functions/ingest-youtube.js
@@ -40,6 +40,11 @@ function parseDuration(iso) {
 }
 
 /**
+ * YouTube URL から videoId を抽出（null安全）
+ */
+function ytId(url){ if(!url) return null; const m=String(url).match(/(?:v=|youtu\.be\/|embed\/)([a-zA-Z0-9_-]{11})/); return m?m[1]:null; }
+
+/**
  * タイトル + description からcontent_typeを判定
  * 優先順: shorts → live → announcement → song
  */
@@ -231,28 +236,43 @@ exports.handler = async (event) => {
         const videoDetails = {};
         (vtData.items || []).forEach(v => { videoDetails[v.id] = v; });
 
-        // (e) Supabase で既存URL突合（全件fetch禁止 — urlリストで絞り込み）
-        // 生成するURLは https://www.youtube.com/watch?v=VIDEOID 形式で & を含まないため安全
-        const candidateUrls = videoIds.map(id => `https://www.youtube.com/watch?v=${id}`);
-        const inFilter = candidateUrls.map(u => `"${u}"`).join(',');
-        const existingRes = await sbFetch(
-          `${SUPABASE_URL}/rest/v1/videos?select=url&url=in.(${inFilter})`,
+        // (e) Supabase で既存videoId突合（pending含む全件 — status不問でないと重複取りこぼし）
+        // 憲法5: 1,000件超は limit=10000&offset=0 を明示（デフォルトLIMIT 1000でsilent drop）
+        const existingRows = await sbFetch(
+          `${SUPABASE_URL}/rest/v1/videos?select=url&limit=10000&offset=0`,
           { headers: { apikey: SUPABASE_KEY, Authorization: `Bearer ${SUPABASE_KEY}` } }
         );
-        const existingUrls = new Set(
-          Array.isArray(existingRes) ? existingRes.map(v => v.url) : []
+        const existingVideoIds = new Set(
+          (Array.isArray(existingRows) ? existingRows : []).map(r => ytId(r.url)).filter(Boolean)
         );
+
+        // playlistPubマップ: videoId → playlistItemのpublishedAt（詳細未取得時の公開日フォールバック用）
+        const playlistPubMap = {};
+        for (const item of newItems) {
+          const vid = item.snippet?.resourceId?.videoId;
+          const pub = item.snippet?.publishedAt;
+          if (vid && pub) playlistPubMap[vid] = pub;
+        }
 
         // (f) content_type分類 + member確定 + カバー検出
         const toInsert = [];
-        let latestPublishedAt = cursor;
+        const resolvedPubs = [];    // カーソル計算用（既存・新規問わず詳細取得済み）
+        const missingPubs = [];     // details未取得動画のpublishedAt（playlistItem側）
+        const seenInBatch = new Set(); // バッチ内重複videoId防止
+        let existingCount = 0;
 
         for (const videoId of videoIds) {
-          const url = `https://www.youtube.com/watch?v=${videoId}`;
-          if (existingUrls.has(url)) continue;
+          if (seenInBatch.has(videoId)) continue;
+          seenInBatch.add(videoId);
 
+          const playlistPub = playlistPubMap[videoId] || null;
           const detail = videoDetails[videoId];
-          if (!detail) continue;
+
+          if (!detail) {
+            // details未取得（削除/非公開/プレミア処理中等）
+            if (playlistPub) missingPubs.push(playlistPub);
+            continue;
+          }
 
           const snippet = detail.snippet || {};
           const contentDetails = detail.contentDetails || {};
@@ -260,9 +280,16 @@ exports.handler = async (event) => {
 
           const title = snippet.title || '';
           const description = snippet.description || '';
-          const publishedAt = snippet.publishedAt || null;
+          const publishedAt = snippet.publishedAt || playlistPub || null;
           const durationSec = parseDuration(contentDetails.duration);
           const hasLiveDetails = !!liveDetails;
+
+          if (existingVideoIds.has(videoId)) {
+            // 既存動画（pending含む）—— INSERTしないがカーソルには寄与
+            if (publishedAt) resolvedPubs.push(publishedAt);
+            existingCount++;
+            continue;
+          }
 
           const contentType = classifyContentType(title, description, durationSec, hasLiveDetails);
           const member = resolveMember(channel.member_id, title);
@@ -274,7 +301,7 @@ exports.handler = async (event) => {
           const date = publishedAt ? publishedAt.slice(0, 10) : null;
 
           toInsert.push({
-            url,
+            url: `https://www.youtube.com/watch?v=${videoId}`,
             title,
             date,
             member,
@@ -288,13 +315,7 @@ exports.handler = async (event) => {
             ingested_at: new Date().toISOString()
           });
 
-          // カーソル更新候補
-          if (publishedAt) {
-            const pubDate = new Date(publishedAt);
-            if (!latestPublishedAt || pubDate > latestPublishedAt) {
-              latestPublishedAt = pubDate;
-            }
-          }
+          if (publishedAt) resolvedPubs.push(publishedAt);
         }
 
         // (g) INSERT（status='pending', source='youtube_auto', ingested_at=now()）
@@ -316,12 +337,27 @@ exports.handler = async (event) => {
           }
         }
 
-        // (h) カーソル更新（last_checked_at + last_video_published_at）
+        // (h) M3 カーソルクランプ（7日ガード込み）
+        // 7日以内のmissing（プレミア処理中等）のみクランプ対象。7日超は削除/非公開の居座りとみなし通過許可
+        const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+        const recentMissingPubs = missingPubs.filter(p => new Date(p) > sevenDaysAgo);
+        const minMissing = recentMissingPubs.length > 0
+          ? recentMissingPubs.reduce((min, p) => p < min ? p : min)
+          : null;
+
+        let newCursor = cursor;
+        for (const p of resolvedPubs) {
+          const d = new Date(p);
+          if (minMissing && d >= new Date(minMissing)) continue; // 未取得動画を追い越さない
+          if (!newCursor || d > newCursor) newCursor = d;
+        }
+
+        // カーソル更新（last_checked_at + last_video_published_at）
         const cursorUpdate = { last_checked_at: new Date().toISOString() };
-        if (latestPublishedAt) {
-          cursorUpdate.last_video_published_at = latestPublishedAt instanceof Date
-            ? latestPublishedAt.toISOString()
-            : latestPublishedAt;
+        if (newCursor) {
+          cursorUpdate.last_video_published_at = newCursor instanceof Date
+            ? newCursor.toISOString()
+            : newCursor;
         }
         await fetch(
           `${SUPABASE_URL}/rest/v1/ingest_channels?id=eq.${channel.id}`,
@@ -337,7 +373,8 @@ exports.handler = async (event) => {
           member_id: channel.member_id,
           new_items: newItems.length,
           inserted,
-          skipped: newItems.length - toInsert.length - (toInsert.length - inserted)
+          existing: existingCount,
+          no_detail_skipped: missingPubs.length
         });
 
       } catch (channelErr) {


### PR DESCRIPTION
## 目的
PR #110（YouTube自動取り込み）のreviewer指摘 MEDIUM 2件（M2/M3）を解消する追随PR。無人稼働（6時間ごと）で静かに蓄積・欠落する2つの不具合を潰す。対象は `netlify/functions/ingest-youtube.js` の1ファイルのみ。

## 変更したもの
- **M2: 重複突合をvideoId正規化** — 既存曲の突合をURL完全一致から videoId 正規化に変更。app.js:143 と同一正規表現の `ytId()` をFunction内に移植（null安全化）。既存videos全件の `url` 列を取得し `existingVideoIds` Set を構築して突合。これにより `https://youtu.be/ID`・`watch?v=ID&list=...` 形式で登録済みの曲を「未登録」誤判定して6時間ごとに重複pendingを量産する回帰を停止。
- **M3: カーソル恒久スキップ防止** — カーソル(`last_video_published_at`)を「詳細取得成功動画の最大publishedAt、**ただし詳細未取得動画の最小publishedAt未満**」にクランプ。プレミア公開直後等でYouTubeが `videos.list` を返さない動画が恒久欠落するのを防ぐ。削除/非公開が居座るケース対策として、missingのうち publishedAt が now-7日より古いものはクランプ対象外（カーソル通過を許可、Yuki承認済み）。
- **M-1（reviewer追加指摘）** — 既存videos全件fetchをチャンネルループ**外**に1回だけホイスト＋取得件数が上限10000に達したら 500 で取り込み中止（PostgRESTのsilent dropでdedupが不完全化し重複を量産するのを防ぐ安全弁）。
- **M-2（reviewer追加指摘）** — `!detail` 分岐冒頭で既存videoIdはカーソル保護せずスキップ。既知動画が一時的にdetails欠落してもカーソルが最大7日停滞しないよう修正。
- **NIT解消** — 意味不明だった `skipped` 集計式を廃止し、`inserted / existing / no_detail_skipped` の明示3カウントに変更（無人稼働の観測性向上）。

## 変更していないもの（保証事項）
- INSERTの `status:'pending'` 固定は不変（自動publish禁止・憲法10）。`published` の書き込みはゼロ。
- 既存突合fetchに `status=published` フィルタは**付けない**（pending含む全既存と突合しないと重複を取りこぼすため。これは公開表示クエリではなく内部dedup）。公開漏洩経路なし。
- 全件fetchは `limit=10000&offset=0` 明示（憲法5の `.range(0,9999)` 等価）。
- 手動起動ガード（ADMIN_PASSWORD Bearer / isScheduled分岐）・sbHeaders・スケジュール構文・PATCH群は無改変。
- フロント（app.js / style.css）・localStorageキー・CSSスコープ・window露出には一切触れていない（差分は当該Function1ファイルのみ）。

## レビュー往復履歴（reviewerの指摘と対応）
- **1巡目**: reviewer判定 APPROVE（CRITICAL/HIGHゼロ）。MEDIUM 2件（M-1: 全件fetchのループ内配置＋10000件上限、M-2: 既存動画によるカーソル7日停滞）を指摘。いずれも「安全側に壊れる」ため差し戻し必須ではないが改善推奨。
- **対応**: 同一ブランチで M-1（ループ外ホイスト＋上限500ガード）と M-2（既存videoIdスキップ）を追加コミット `10cb2ad`。
- verifier 全7チェック再PASS。

## 動作確認方法（Yuki向け手順）
**前提**: `ingest_channels` に `enabled=true` のチャンネルが1件以上登録済み。デプロイプレビューURLで実施。

1. **ベースライン記録** — Supabaseで `videos` 件数・最新 `ingested_at`、`ingest_channels.last_video_published_at`（カーソル）を控える。
2. **手動起動** — `curl -i -X GET "https://<preview>/.netlify/functions/ingest-youtube" -H "Authorization: Bearer <ADMIN_PASSWORD>"` → HTTP 200・`ok:true`、`results` 各チャンネルに `inserted/existing/no_detail_skipped` が返ること。
3. **M2重複突合** — 同じcurlを**もう一度**実行 → 2回目は `inserted:0` / `existing:N`。videos件数が増えず、同一videoIdの重複行が無いこと。
4. **M3カーソル** — `last_video_published_at` が前進 or 同値（**後退しない**こと）。
5. **10000件ガード** — Netlify Functionsログに `videos件数が全件fetch上限` が出ていない（=正常）こと。
6. **異常系** — Authorizationヘッダ無しで叩き `401` が返ること。

verifier結果: `node --check` PASS / 憲法5・10充足を静的確認 / 差分は当該Function1ファイルに限定。

## 判断保留リスト
- **playlist-import.js:30** — planner が発見した同種の憲法5潜在違反（`videos?select=id,url` のrange未指定）。本PRスコープ外。別PRで対応要否を判断。
- **将来のvideos 1万件超** — 現状の単発 `limit=10000` は上限到達時に500で安全停止するが、恒久対応にはページング実装が必要（上限ガードが発火したら着手）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
