### PR TITLE
fix(playlist-import): 全件fetchのrange明示+上限ガード / 突合のvideoId正規化 / プレイリスト内重複排除（憲法5 + M2同型）

### DIFF
--- a/netlify/functions/playlist-import.js
+++ b/netlify/functions/playlist-import.js
@@ -1,3 +1,6 @@
+// URLからYouTube videoId（11文字）を抽出（ingest-youtube.jsと同一）
+function ytId(url){ if(!url) return null; const m=String(url).match(/(?:v=|youtu\.be\/|embed\/)([a-zA-Z0-9_-]{11})/); return m?m[1]:null; }
+
 exports.handler = async (event) => {
   if (event.httpMethod !== 'POST') return { statusCode: 405, body: 'Method Not Allowed' };
   let body;
@@ -27,11 +30,17 @@ exports.handler = async (event) => {
   }
 
   // 既存動画を全件取得（url と id を取得）
-  const existRes = await fetch(`${supaUrl}/rest/v1/videos?select=id,url`, {
+  // 憲法5: PostgRESTデフォルトLIMIT1000のsilent dropを防ぐためlimit/offset明示
+  const existRes = await fetch(`${supaUrl}/rest/v1/videos?select=id,url&limit=10000&offset=0`, {
     headers: { apikey: supaKey, Authorization: `Bearer ${supaKey}` }
   });
   const existData = await existRes.json();
-  const existingMap = new Map((existData || []).map(v => [v.url, v.id]));
+  // 上限到達時は突合不完全＝重複公開の恐れがあるため中止
+  if (Array.isArray(existData) && existData.length >= 10000) {
+    return { statusCode: 500, body: JSON.stringify({ error: 'videos件数が全件fetch上限(10000)に到達。ページング未実装のため安全のため中止。', count: existData.length }) };
+  }
+  const existingMap = new Map();
+  (existData || []).forEach(v => { const vid = ytId(v.url); if (vid) existingMap.set(vid, v.id); });
 
   const toInsert = [];
   const toLink = []; // 既存曲でアルバムに紐付けるもの
@@ -39,9 +48,10 @@ exports.handler = async (event) => {
   for (const item of allItems) {
     const videoId = item.snippet.resourceId.videoId;
     const url = `https://www.youtube.com/watch?v=${videoId}`;
-    if (existingMap.has(url)) {
+    // 突合はvideoIdベース（既存データのURL形式混在に対応）
+    if (existingMap.has(videoId)) {
       // 既存曲：album_idが指定されていれば紐付け対象に
-      if (album_id) toLink.push(existingMap.get(url));
+      if (album_id) toLink.push(existingMap.get(videoId));
       continue;
     }
     toInsert.push({

--- a/netlify/functions/playlist-import.js
+++ b/netlify/functions/playlist-import.js
@@ -44,6 +44,7 @@ exports.handler = async (event) => {
 
   const toInsert = [];
   const toLink = []; // 既存曲でアルバムに紐付けるもの
+  const seen = new Set(); // 同一プレイリスト内の重複videoIdによる二重INSERT防止
 
   for (const item of allItems) {
     const videoId = item.snippet.resourceId.videoId;
@@ -54,6 +55,8 @@ exports.handler = async (event) => {
       if (album_id) toLink.push(existingMap.get(videoId));
       continue;
     }
+    if (seen.has(videoId)) continue; // バッチ内重複を弾く（公開重複カード防止）
+    seen.add(videoId);
     toInsert.push({
       member, title: item.snippet.title, url,
       date: item.snippet.publishedAt ? item.snippet.publishedAt.slice(0, 10) : '',


### PR DESCRIPTION
## 目的
planner が PR #111 の作業中に発見した、`playlist-import.js`（admin手動プレイリスト一括インポート）の憲法5潜在違反と、それに隣接する同型のdedup不備を解消する。このFunctionはINSERT時に `status` 未指定＝migrationのDEFAULT `published` で**即公開**されるため（admin手動操作なので意図通り）、突合漏れは**公開サイトに重複カードを出す**＝影響が大きい。対象は `netlify/functions/playlist-import.js` の1ファイルのみ。

## 変更したもの
- **憲法5対応** — 既存videos全件fetchが `videos?select=id,url`（range未指定）でPostgRESTデフォルトLIMIT1000のsilent dropに晒されていた。1000件超だと1001件目以降が突合対象から漏れ、既存曲を「新規」誤判定して重複INSERT→公開重複カード。`?select=id,url&limit=10000&offset=0` を明示（`.range(0,9999)` 等価）し、取得件数が上限10000に達したらdedup不完全＝重複量産の恐れがあるため **500で取り込み中止**する安全弁を追加（`existingMap` 構築の前に配置）。
- **突合のvideoId正規化（M2同型）** — 既存突合がURL完全一致（`existingMap.has(url)`）依存で、`youtu.be/ID`・`watch?v=ID&list=...` 形式で登録済みの曲を「新規」誤判定していた。ingest-youtube と同一の `ytId()` を移植し、`existingMap` を `videoId→id` で構築、突合を `has(videoId)` に変更。INSERT時の `url` は正準形 `watch?v=ID` のまま保存（突合キーだけvideoId化）。
- **プレイリスト内重複の排除** — YouTubeのユーザ作成プレイリストは同一動画の重複登録を許容するため、同一videoIdが複数含まれると二重INSERT→公開重複カードになり得た。`seen` Set をループに追加してバッチ内重複を排除（ingest-youtube の `seenInBatch` と対称）。

## 変更していないもの（保証事項）
- INSERTオブジェクトに `status` を**足していない**（DEFAULT `published` のまま。admin手動publishは意図通り。勝手に `pending` も付けない・憲法10）。
- 突合fetchに `status=published` フィルタは付けない（内部dedup用途。pending含む全既存と突合しないと重複を取りこぼす）。
- 認証（ADMIN_PASSWORD）・playlistId正規表現検証・YouTubeページング取得ループ（200件上限）・PATCHによるalbum紐付け・戻り値の集計メッセージは無改変。
- 差分は `playlist-import.js` 1ファイル（+17 / -4）。フロント・localStorage・CSSスコープ・window露出には一切触れていない。

## レビュー往復履歴（reviewerの指摘と対応）
- **1巡目**: reviewer判定 APPROVE（CRITICALゼロ）。WARNING 1件（プレイリスト内の同一videoId重複が未dedup → 公開重複カード。既存の穴の踏襲でこのPRの回帰ではないが、本PRの主目的「重複公開防止」を完全に満たすなら `seen` Set 追加を推奨）を指摘。
- **対応**: 同一ブランチで `seen` Set を追加（コミット `4d4d602`）。既存曲側の重複album紐付けは `linked` が過大になるだけで実害・表示影響なしのため対象外とした。
- verifier 全7項目 再PASS。

## 動作確認方法（Yuki向け手順）
デプロイプレビューURLで実施。所要約5分。

1. **準備** — 既登録曲を1曲以上含むYouTubeプレイリストID（`PLxxxx`）を用意。
2. **インポート** — `/admin` ログイン → SONGS総件数をメモ → IMPORTモーダルでプレイリストID・MEMBER（任意でALBUM）指定 → 実行。結果が `INSERTED: N / SKIPPED: M`、エラー無しであること。
3. **件数整合** — SONGS総件数が「メモ + INSERTED」と一致。
4. **重複防止** — 同じプレイリストIDで**もう一度**実行 → `INSERTED: 0`、重複カードが増えないこと。
5. **album紐付け** — ALBUM指定時、既存曲・新規曲ともに該当アルバムに紐付くこと。
6. **公開サイト** — トップ（`/`）でインポートした曲のタイトルを検索し、重複カードが無いこと。

verifier結果: `node --check` PASS / 憲法5・10充足を静的確認 / 差分1ファイル限定。動的（netlify dev）は環境変数未設定のためSKIP。

## 判断保留リスト
- **`existRes.ok` 未チェック（NIT）** — Supabaseがエラー応答を返すと `existData` がオブジェクトになり `.forEach` で例外→500。旧コードと同一挙動で本PRの回帰ではないため今回スコープ外。防御的に足すなら別途。
- **既存曲側の重複album紐付け** — `toLink` に同一idが複数入り `linked` が過大になり得るが、`admin.js` の表示に出ず算術も破綻しないため実害なし。今回は未対応。
- **将来のvideos 1万件超** — 単発 `limit=10000` は上限で500安全停止するが、恒久対応にはページング実装が必要（ingest-youtube と共通課題）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
