### PR TITLE
fix(admin-query): playlist-import actionに #111/#112 の修正を同型移植（憲法5違反hotfix）

### DIFF
--- a/netlify/functions/admin-query.js
+++ b/netlify/functions/admin-query.js
@@ -9,6 +9,9 @@
 //   { action:"youtube", videoId }                          — YouTube metadata
 //   { action:"playlist-import", playlistId, member, tags, album_id } — Bulk import
 
+// URLからYouTube videoId（11文字）を抽出（playlist-import.js / ingest-youtube.jsと同一）
+function ytId(url){ if(!url) return null; const m=String(url).match(/(?:v=|youtu\.be\/|embed\/)([a-zA-Z0-9_-]{11})/); return m?m[1]:null; }
+
 const crypto = require('crypto');
 
 exports.handler = async (event) => {
@@ -109,48 +112,77 @@ exports.handler = async (event) => {
       const YT_KEY = process.env.YOUTUBE_API_KEY;
       if (!YT_KEY) return resp(500, { error: 'YOUTUBE_API_KEY not configured' });
 
-      // Fetch all playlist items
-      let items = [], nextPage = '';
-      do {
+      // YouTubeプレイリスト全件取得（最大200件）
+      let allItems = [], pageToken = '';
+      while (true) {
         const pUrl = 'https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&maxResults=50&playlistId='
-          + playlistId + '&key=' + YT_KEY + (nextPage ? '&pageToken=' + nextPage : '');
+          + encodeURIComponent(playlistId) + '&key=' + YT_KEY + (pageToken ? '&pageToken=' + encodeURIComponent(pageToken) : '');
         const pRes = await fetch(pUrl);
         const pData = await pRes.json();
         if (pData.error) return resp(400, { error: 'YouTube API: ' + (pData.error.message || 'Unknown') });
-        (pData.items || []).forEach(i => {
-          const s = i.snippet;
-          if (s.title === 'Deleted video' || s.title === 'Private video') return;
-          items.push({
-            url: 'https://www.youtube.com/watch?v=' + s.resourceId.videoId,
-            title: s.title,
-            date: (s.publishedAt || '').slice(0, 10),
-            member: member,
-            tags: tags || '',
-            note: '',
-            spotify_url: null,
-            album_id: album_id || null
-          });
+        const pageItems = (pData.items || []).filter(i => i.snippet.resourceId.kind === 'youtube#video');
+        allItems = allItems.concat(pageItems);
+        if (pData.nextPageToken && allItems.length < 200) { pageToken = pData.nextPageToken; } else break;
+      }
+
+      // 既存動画を全件取得（url と id を取得）
+      // 憲法5: PostgRESTデフォルトLIMIT1000のsilent dropを防ぐためlimit/offset明示
+      const exRes = await fetch(SUPABASE_URL + '/rest/v1/videos?select=id,url&limit=10000&offset=0', { headers: sbHeaders });
+      const existData = await exRes.json();
+      // 上限到達時は突合不完全＝重複公開の恐れがあるため中止
+      if (Array.isArray(existData) && existData.length >= 10000) {
+        return resp(500, { error: 'videos件数が全件fetch上限(10000)に到達。ページング未実装のため安全のため中止。', count: existData.length });
+      }
+      const existingMap = new Map();
+      (Array.isArray(existData) ? existData : []).forEach(v => { const vid = ytId(v.url); if (vid) existingMap.set(vid, v.id); });
+
+      const toInsert = [];
+      const toLink = []; // 既存曲でアルバムに紐付けるもの
+      const seen = new Set(); // 同一プレイリスト内の重複videoIdによる二重INSERT防止
+
+      for (const item of allItems) {
+        const videoId = item.snippet.resourceId.videoId;
+        const url = 'https://www.youtube.com/watch?v=' + videoId;
+        // 突合はvideoIdベース（既存データのURL形式混在に対応）
+        if (existingMap.has(videoId)) {
+          if (album_id) toLink.push(existingMap.get(videoId));
+          continue;
+        }
+        if (seen.has(videoId)) continue; // バッチ内重複を弾く（公開重複カード防止）
+        seen.add(videoId);
+        toInsert.push({
+          url, title: item.snippet.title,
+          date: item.snippet.publishedAt ? item.snippet.publishedAt.slice(0, 10) : '',
+          member: member, tags: tags || '', note: '', album_id: album_id || null
         });
-        nextPage = pData.nextPageToken || '';
-      } while (nextPage);
+      }
 
-      // Get existing URLs
-      const exRes = await fetch(SUPABASE_URL + '/rest/v1/videos?select=url', { headers: sbHeaders });
-      const existing = await exRes.json();
-      const existingUrls = new Set((Array.isArray(existing) ? existing : []).map(v => v.url));
+      // 既存曲をアルバムに紐付け（PATCH）
+      let linked = 0;
+      if (album_id && toLink.length > 0) {
+        for (const id of toLink) {
+          await fetch(SUPABASE_URL + '/rest/v1/videos?id=eq.' + id, {
+            method: 'PATCH',
+            headers: { ...sbHeaders, 'Content-Type': 'application/json', Prefer: 'return=minimal' },
+            body: JSON.stringify({ album_id })
+          });
+          linked++;
+        }
+      }
 
-      const newItems = items.filter(i => !existingUrls.has(i.url));
       let inserted = 0;
-      if (newItems.length > 0) {
+      if (toInsert.length > 0) {
         const insRes = await fetch(SUPABASE_URL + '/rest/v1/videos', {
           method: 'POST',
           headers: { ...sbHeaders, 'Content-Type': 'application/json', Prefer: 'return=minimal' },
-          body: JSON.stringify(newItems)
+          body: JSON.stringify(toInsert)
         });
-        if (insRes.ok) inserted = newItems.length;
+        if (insRes.ok) inserted = toInsert.length;
+        else { const errText = await insRes.text(); return resp(500, { error: errText }); }
       }
 
-      return resp(200, { total: items.length, skipped: items.length - newItems.length, inserted });
+      const total = allItems.length;
+      return resp(200, { total, inserted, skipped: total - inserted - linked, linked });
     }
 
     return resp(400, { error: 'Unknown action: ' + action });

--- a/public/admin.js
+++ b/public/admin.js
@@ -841,7 +841,7 @@ MU.Tabs.register('songs', {
             try {
               var result = await MU.DB.playlistImport(plId, member, tags, albumId);
               document.getElementById('import-result').innerHTML =
-                MU.UI.alert('COMPLETE — TOTAL: ' + result.total + ' / INSERTED: ' + result.inserted + ' / SKIPPED: ' + result.skipped, 'ok');
+                MU.UI.alert('COMPLETE — TOTAL: ' + result.total + ' / INSERTED: ' + result.inserted + ' / SKIPPED: ' + result.skipped + ' / LINKED: ' + (result.linked || 0), 'ok');
               // Disable OK button to prevent double import
               var okBtn = document.getElementById('modal-ok');
               if (okBtn) { okBtn.disabled = true; okBtn.textContent = 'DONE'; }


### PR DESCRIPTION
## 目的

監査レポート（PR #113 / docs/REFACTOR_AUDIT.md Section 11-(c)）で判明した憲法5違反の先行hotfix。
`admin-query.js` の `playlist-import` action は単体Function `playlist-import.js` の旧版コピーで、PR #111/#112 で単体側に入った修正が未適用だった。既存videos突合のfetchがlimit未指定のためPostgRESTデフォルトLIMIT 1000でsilent dropし（videosは1,286件超）、**既存曲が重複INSERTされ、DBデフォルト status='published' により重複が即公開され得る**状態だった。

## 変更したもの

- `netlify/functions/admin-query.js`（playlist-import actionのみ + ytIdヘルパー追加）:
  - 既存videos全件fetchに `limit=10000&offset=0` 明示 + 10,000件到達時の中止ガード（憲法5対応、playlist-import.jsと同型）
  - 突合をURL文字列比較 → videoId正規化ベースに変更（`ytId()` はplaylist-import.js:2と文字単位で同一）
  - プレイリスト内の同一videoId重複を seen Set で排除
  - playlistItemsページングに200件キャップ
  - **挙動追加（同型移植に含まれる）**: album_id指定時、既存曲をアルバムに紐付ける `linked` 処理（従来のadmin経路はスキップのみ。playlist-import.js側には既に存在する挙動で、二重実装の片側だけ欠けていた）。これに伴い `skipped` は「既存のうちlinkedを除いた数」に変化
- `public/admin.js:844` の1行のみ: インポート結果表示に `LINKED: N` を追加（reviewer M-2対応。`result.linked || 0` で旧レスポンスにも安全）

## 変更していないもの（保証事項）

- admin-query.js の他action（query / insert / update / delete / youtube）は diff ゼロ（verifierが機械確認）
- レスポンス契約: `total` / `inserted` / `skipped` は維持（admin.js:844 が参照する3フィールド）
- 認証（sha256トークン）・CORS・エラー形式は無変更
- statusフィールドの扱いは従来どおり未指定（=DBデフォルトpublished）。人間操作のadmin一括インポートであり憲法10の対象外、従来挙動を維持
- 公開サイト側・他のFunctionsには一切触れていない

## レビュー往復履歴（reviewerの指摘と対応）

- reviewer判定: **APPROVE**(CRITICAL/HIGHゼロ)
  - M-1: linked処理はスコープ超えの挙動追加 → 正(playlist-import.js)との同型移植として妥当と判定、PR説明に明記（本文の「変更したもの」参照）
  - M-2: linkedがadmin画面に出ず「全曲既存+album指定」時に INSERTED: 0 / SKIPPED: 0 と誤読され得る → admin.js:844 に LINKED 表示を追加（6c3e58f、1往復）
  - M-3: playlist-import.jsとの残差異は `message` フィールドの有無のみ（admin.jsは未参照、機能影響なし）
  - L-2: ブランチ版の `Array.isArray` ガードは正より堅牢（良化方向の差異）
- verifier判定: **PASS**（構文チェック / ytId正規化・seen Set・突合の単体13ケース全通過 / レスポンス契約 / ytId同型性diffゼロ / 他action無風）

## 動作確認方法（Yuki向け手順）

デプロイプレビューの `/admin.html` で、一部登録済み・一部未登録の曲が混在するプレイリストIDを使用（所要5分）:

1. **基本インポート**（ALBUM ID空欄）→ `COMPLETE — TOTAL: N / INSERTED: X / SKIPPED: Y / LINKED: 0` が出ること
2. **同じプレイリストをALBUM ID指定で再実行** → `INSERTED: 0 / LINKED: Z (>0)` が出て、SONGSリストで該当曲のalbum紐付けを目視確認
3. **同じプレイリストをもう一度そのまま再実行** → `INSERTED: 0 / SKIPPED: N` で重複カードがSONGSリストに増えていないこと
4. NGパターン: `LINKED: undefined`/`NaN` 表示、重複カード出現、コンソールエラー

## 判断保留リスト

- 旧admin-query実装にのみあった `Deleted video` / `Private video` タイトルフィルタは正(playlist-import.js)に合わせて不採用（`kind==='youtube#video'` フィルタで代替）。削除済み動画の扱いを厳密化するなら両ファイル同時に別PRで
- admin-query.js の汎用query actionはlimitがクライアント任せ（現状admin.jsは9999明示で実害なし）。サーバ側ガードはPhase 3（Functions共通化）で検討
- admin-query.js playlist-import actionとplaylist-import.jsの二重実装の一本化はPhase 3の筆頭候補（監査レポート記載済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)