### PR TITLE
fix(admin-query): query actionのlimit未指定時にサーバ側で10000を明示（憲法5予防ガード）

### DIFF
--- a/netlify/functions/admin-query.js
+++ b/netlify/functions/admin-query.js
@@ -46,6 +46,8 @@ exports.handler = async (event) => {
       let url = SUPABASE_URL + '/rest/v1/' + body.table + '?select=' + encodeURIComponent(body.select || '*');
       if (body.filter) url += '&' + body.filter;
       if (body.order) url += '&order=' + body.order;
+      // 憲法5: limit未指定時はPostgRESTデフォルトLIMIT 1000でsilent dropするため、サーバ側で明示（playlist-importと同型）
+      if (!body.limit) { body.limit = '10000'; if (!body.offset) body.offset = '0'; }
       if (body.limit) url += '&limit=' + body.limit;
       if (body.offset) url += '&offset=' + body.offset;
       const res = await fetch(url, { headers: sbHeaders });


### PR DESCRIPTION
## 目的

B0監査・PR #114で判断保留になっていた予防的修正（承認済み、B3の前提PR）。admin-query.js の汎用query actionはlimitをクライアント任せにしており、省略されるとPostgRESTデフォルトLIMIT 1000でsilent dropする構造だった。

## 変更したもの

- admin-query.js に **+2行のみ**: limit未指定時にサーバ側で `limit=10000&offset=0` を明示（同ファイルplaylist-import actionの既存パターンと同型）

## 変更していないもの（保証事項）

- **limit明示時のクエリ文字列はバイト単位で不変**（bodyのデフォルトを埋める方式で、URL組み立て行には触れていない）
- public/admin.js の全query呼び出し8箇所はすべてlimit明示（9999×6 / 999 / 50）のため、**admin画面の実挙動は一切変わらない**。純粋な予防ガード
- 他action・認証・CORS・レスポンス形式は無変更

## レビュー往復履歴

+2行のためオーケストレーターがdiff全文を直接確認（limit明示時の無変異・エッジケース offset単独指定・falsy空文字の扱いを検証）。B3本体のスナップショットテストがマージ後のベースラインとして本ガードを織り込む。

## 動作確認方法

1. Files changedが admin-query.js の+2行のみであることを確認
2. マージ後、admin画面のSONGS/BOTTLESリストが従来どおり表示されること（1分）

## 判断保留リスト

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)