### PR TITLE
refactor(phase3): Netlify Functions共通化 — _shared導入 + 入出力スナップショット同値保証（PR-B3）

### DIFF
--- a/netlify/functions/_shared/client-hash.js
+++ b/netlify/functions/_shared/client-hash.js
@@ -1,0 +1,20 @@
+// netlify/functions/_shared/client-hash.js
+// SHA-256計算の単一実装（admin-auth発行 / admin-query検証 / exchange clientHash）
+// 注意: 認証4方式そのものは統一しない（B3計画§3）。ここはハッシュ計算のみ。
+
+const crypto = require('crypto');
+
+/** SHA-256 hex */
+function sha256Hex(input) {
+  return crypto.createHash('sha256').update(input).digest('hex');
+}
+
+/** NetlifyのクライアントIPヘッダ → SHA-256（observer-link-exchangeの現行実装と同一） */
+function getClientHash(event) {
+  // Use Netlify's reliable client IP header, fall back to x-forwarded-for
+  const ip = (event.headers['x-nf-client-connection-ip']
+    || (event.headers['x-forwarded-for'] || '127.0.0.1').split(',')[0]).trim();
+  return sha256Hex(ip);
+}
+
+module.exports = { sha256Hex, getClientHash };

--- a/netlify/functions/_shared/responses.js
+++ b/netlify/functions/_shared/responses.js
@@ -1,0 +1,32 @@
+// netlify/functions/_shared/responses.js
+// 定型レスポンス（完全同形のもののみ共通化 — B3計画§3）
+// 対象外: JSON形式の405（admin-auth / admin-query / exchange）、admin-auth独自の
+// 'PARSE ERROR — MALFORMED REQUEST'、CORS 3パターン、エラーレスポンス3系統 — すべてローカル維持。
+
+/** 平文405（headersキーなし・現行10ファイル同形） */
+function methodNotAllowed() {
+  return { statusCode: 405, body: 'Method Not Allowed' };
+}
+
+/** JSONパース失敗の400（headersキーなし・同文のもののみ） */
+function invalidJson() {
+  return { statusCode: 400, body: JSON.stringify({ error: 'Invalid JSON' }) };
+}
+
+/** JSONレスポンス。headers省略時はheadersキー自体を含めない（現行形状の維持） */
+function json(statusCode, bodyObj, headers) {
+  return headers
+    ? { statusCode, headers, body: JSON.stringify(bodyObj) }
+    : { statusCode, body: JSON.stringify(bodyObj) };
+}
+
+/** event.body のJSONパース。現行の `JSON.parse(event.body || '{}')` と同値 */
+function parseJsonBody(event) {
+  try {
+    return { ok: true, body: JSON.parse(event.body || '{}') };
+  } catch {
+    return { ok: false };
+  }
+}
+
+module.exports = { methodNotAllowed, invalidJson, json, parseJsonBody };

--- a/netlify/functions/_shared/supabase.js
+++ b/netlify/functions/_shared/supabase.js
@@ -1,0 +1,60 @@
+// netlify/functions/_shared/supabase.js
+// Supabase接続の共通ヘルパー（内部実装の重複排除のみ。外部挙動は1バイトも変えない）
+// キー選択は現行の3変種を意図的に分離して維持する（統一しない — B3計画§3）
+// 注意: env欠落チェックは共通化しない（有→有、無→無の現状維持。各Function側の責務）
+
+/** SUPABASE_URL */
+function getSupabaseUrl() {
+  return process.env.SUPABASE_URL;
+}
+
+/** 変種A: 書き込み系（admin CRUD / admin-query / ingest 等）が使う secret key */
+function secretKey() {
+  return process.env.SUPABASE_SECRET_KEY;
+}
+
+/** 変種B: 公開read系（albums-get / videos-get）。ANON優先、未設定ならSECRETにフォールバック */
+function readKey() {
+  return process.env.SUPABASE_ANON_KEY || process.env.SUPABASE_SECRET_KEY;
+}
+
+/** 変種C: Observer-Link系（exchange / result）。SERVICE_ROLE優先、未設定ならSECRETにフォールバック */
+function serviceKey() {
+  return process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SECRET_KEY;
+}
+
+/** PostgREST用ヘッダ。extra で Content-Type / Prefer 等の現行の揺れをそのまま維持する */
+function sbHeaders(key, extra = {}) {
+  return { apikey: key, Authorization: `Bearer ${key}`, ...extra };
+}
+
+/**
+ * Supabase fetch ラッパー（非OK時はthrow）。
+ * errSlice: エラーテキストの切り詰め長（exchange=200 / ingest=300 の現行差をパラメタ化して維持）
+ */
+async function sbFetch(url, options, { errSlice = 200 } = {}) {
+  const res = await fetch(url, options);
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Supabase ${res.status}: ${text.slice(0, errSlice)}`);
+  }
+  return res.json();
+}
+
+/**
+ * videos全件fetch（憲法5: limit=10000&offset=0 明示）+ 上限到達ガード。
+ * 10000到達時はthrowせず overflow フラグで返す — 500 bodyの文言は各Functionが現行のまま組み立てる
+ * （ingest / playlist-import / admin-query で文言が異なるため）。
+ * throwOnHttpError=true: 非OK時にthrow（ingest-youtubeの現行挙動）。
+ * false: 現行どおり res.ok 未チェックで res.json()（playlist-import / admin-queryの現行挙動）。
+ */
+async function fetchAllVideoRows(supaUrl, key, select, { throwOnHttpError = false, errSlice = 200 } = {}) {
+  const url = `${supaUrl}/rest/v1/videos?select=${select}&limit=10000&offset=0`;
+  const rows = throwOnHttpError
+    ? await sbFetch(url, { headers: sbHeaders(key) }, { errSlice })
+    : await (await fetch(url, { headers: sbHeaders(key) })).json();
+  const isArray = Array.isArray(rows);
+  return { rows, overflow: isArray && rows.length >= 10000, count: isArray ? rows.length : 0 };
+}
+
+module.exports = { getSupabaseUrl, secretKey, readKey, serviceKey, sbHeaders, sbFetch, fetchAllVideoRows };

--- a/netlify/functions/_shared/yt.js
+++ b/netlify/functions/_shared/yt.js
@@ -1,0 +1,32 @@
+// netlify/functions/_shared/yt.js
+// YouTube関連の共通ヘルパー
+// 対象外（B3計画§2）:
+//   - 単発動画メタ取得（youtube.js と admin-query でサムネ優先順位等の外部差異があるため）
+//   - result.js の extractYtId（別実装・挙動差があるため触らない）
+//   - ingest-youtube の playlistItems 1ページ50件取得（意図的仕様のため使わない）
+
+// URLからYouTube videoId（11文字）を抽出（null安全）
+function ytId(url){ if(!url) return null; const m=String(url).match(/(?:v=|youtu\.be\/|embed\/)([a-zA-Z0-9_-]{11})/); return m?m[1]:null; }
+
+/**
+ * playlistItems.list の全ページ取得（kind==='youtube#video' のみ、最大 maxItems 件）。
+ * YouTube APIエラー時は { error: <data.error> } を返す。
+ * エラー文言の整形は呼び出し元の現行実装のまま
+ * （admin-query: 'YouTube API: ' + (message || 'Unknown') / playlist-import: message のみ）。
+ */
+async function fetchAllPlaylistItems(playlistId, apiKey, { maxItems = 200 } = {}) {
+  let allItems = [];
+  let pageToken = '';
+  while (true) {
+    const url = `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&maxResults=50&playlistId=${encodeURIComponent(playlistId)}&key=${apiKey}${pageToken ? '&pageToken=' + encodeURIComponent(pageToken) : ''}`;
+    const res = await fetch(url);
+    const data = await res.json();
+    if (data.error) return { error: data.error };
+    const items = (data.items || []).filter(i => i.snippet.resourceId.kind === 'youtube#video');
+    allItems = allItems.concat(items);
+    if (data.nextPageToken && allItems.length < maxItems) { pageToken = data.nextPageToken; } else break;
+  }
+  return { items: allItems };
+}
+
+module.exports = { ytId, fetchAllPlaylistItems };

--- a/netlify/functions/admin-auth.js
+++ b/netlify/functions/admin-auth.js
@@ -3,7 +3,7 @@
 // Response: { ok: true, token: string } | { ok: false, msg: string }
 // token is a SHA-256 session hash (NOT the Supabase secret key — that stays server-side)
 
-const crypto = require('crypto');
+const { sha256Hex } = require('./_shared/client-hash');
 
 exports.handler = async (event) => {
   const CORS_HEADERS = {
@@ -36,9 +36,7 @@ exports.handler = async (event) => {
       };
     }
 
-    const sessionToken = crypto.createHash('sha256')
-      .update(process.env.ADMIN_PASSWORD)
-      .digest('hex');
+    const sessionToken = sha256Hex(process.env.ADMIN_PASSWORD);
 
     return {
       statusCode: 200,

--- a/netlify/functions/admin-query.js
+++ b/netlify/functions/admin-query.js
@@ -9,10 +9,10 @@
 //   { action:"youtube", videoId }                          — YouTube metadata
 //   { action:"playlist-import", playlistId, member, tags, album_id } — Bulk import
 
-// URLからYouTube videoId（11文字）を抽出（playlist-import.js / ingest-youtube.jsと同一）
-function ytId(url){ if(!url) return null; const m=String(url).match(/(?:v=|youtu\.be\/|embed\/)([a-zA-Z0-9_-]{11})/); return m?m[1]:null; }
-
-const crypto = require('crypto');
+const { getSupabaseUrl, secretKey, sbHeaders: buildSbHeaders, fetchAllVideoRows } = require('./_shared/supabase');
+const { sha256Hex } = require('./_shared/client-hash');
+// URLからYouTube videoId（11文字）を抽出 / プレイリスト全件取得（playlist-import.js / ingest-youtube.jsと共通）
+const { ytId, fetchAllPlaylistItems } = require('./_shared/yt');
 
 exports.handler = async (event) => {
   const CORS = {
@@ -27,14 +27,14 @@ exports.handler = async (event) => {
   if (event.httpMethod !== 'POST') return resp(405, { error: 'Method not allowed' });
 
   const auth = (event.headers.authorization || '').replace(/^Bearer\s+/i, '');
-  const expected = crypto.createHash('sha256').update(process.env.ADMIN_PASSWORD || '').digest('hex');
+  const expected = sha256Hex(process.env.ADMIN_PASSWORD || '');
   if (!auth || auth !== expected) return resp(401, { error: 'Unauthorized' });
 
-  const SUPABASE_URL = process.env.SUPABASE_URL;
-  const SUPABASE_KEY = process.env.SUPABASE_SECRET_KEY;
+  const SUPABASE_URL = getSupabaseUrl();
+  const SUPABASE_KEY = secretKey();
   if (!SUPABASE_URL || !SUPABASE_KEY) return resp(500, { error: 'Supabase env vars missing' });
 
-  const sbHeaders = { apikey: SUPABASE_KEY, Authorization: 'Bearer ' + SUPABASE_KEY };
+  const sbHeaders = buildSbHeaders(SUPABASE_KEY);
 
   try {
     const body = JSON.parse(event.body);
@@ -115,24 +115,15 @@ exports.handler = async (event) => {
       if (!YT_KEY) return resp(500, { error: 'YOUTUBE_API_KEY not configured' });
 
       // YouTubeプレイリスト全件取得（最大200件）
-      let allItems = [], pageToken = '';
-      while (true) {
-        const pUrl = 'https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&maxResults=50&playlistId='
-          + encodeURIComponent(playlistId) + '&key=' + YT_KEY + (pageToken ? '&pageToken=' + encodeURIComponent(pageToken) : '');
-        const pRes = await fetch(pUrl);
-        const pData = await pRes.json();
-        if (pData.error) return resp(400, { error: 'YouTube API: ' + (pData.error.message || 'Unknown') });
-        const pageItems = (pData.items || []).filter(i => i.snippet.resourceId.kind === 'youtube#video');
-        allItems = allItems.concat(pageItems);
-        if (pData.nextPageToken && allItems.length < 200) { pageToken = pData.nextPageToken; } else break;
-      }
+      const pl = await fetchAllPlaylistItems(playlistId, YT_KEY);
+      if (pl.error) return resp(400, { error: 'YouTube API: ' + (pl.error.message || 'Unknown') });
+      const allItems = pl.items;
 
       // 既存動画を全件取得（url と id を取得）
-      // 憲法5: PostgRESTデフォルトLIMIT1000のsilent dropを防ぐためlimit/offset明示
-      const exRes = await fetch(SUPABASE_URL + '/rest/v1/videos?select=id,url&limit=10000&offset=0', { headers: sbHeaders });
-      const existData = await exRes.json();
+      // 憲法5: PostgRESTデフォルトLIMIT1000のsilent dropを防ぐためlimit/offset明示（fetchAllVideoRows）
+      const { rows: existData, overflow } = await fetchAllVideoRows(SUPABASE_URL, SUPABASE_KEY, 'id,url');
       // 上限到達時は突合不完全＝重複公開の恐れがあるため中止
-      if (Array.isArray(existData) && existData.length >= 10000) {
+      if (overflow) {
         return resp(500, { error: 'videos件数が全件fetch上限(10000)に到達。ページング未実装のため安全のため中止。', count: existData.length });
       }
       const existingMap = new Map();

--- a/netlify/functions/albums-add.js
+++ b/netlify/functions/albums-add.js
@@ -1,30 +1,29 @@
+const { getSupabaseUrl, secretKey, sbHeaders } = require('./_shared/supabase');
+const { methodNotAllowed, invalidJson, json, parseJsonBody } = require('./_shared/responses');
+
 exports.handler = async (event) => {
-  if (event.httpMethod !== 'POST') return { statusCode: 405, body: 'Method Not Allowed' };
-  let body = {};
-  try { body = JSON.parse(event.body || '{}'); } catch {
-    return { statusCode: 400, body: JSON.stringify({ error: 'Invalid JSON' }) };
-  }
+  if (event.httpMethod !== 'POST') return methodNotAllowed();
+  const parsed = parseJsonBody(event);
+  if (!parsed.ok) return invalidJson();
+  const body = parsed.body;
   const { password, member, name, purchase_url } = body;
   if (password !== process.env.ADMIN_PASSWORD)
-    return { statusCode: 401, body: JSON.stringify({ error: 'Unauthorized' }) };
+    return json(401, { error: 'Unauthorized' });
   if (!member || !name)
-    return { statusCode: 400, body: JSON.stringify({ error: 'member and name required' }) };
+    return json(400, { error: 'member and name required' });
 
-  const url = process.env.SUPABASE_URL;
-  const key = process.env.SUPABASE_SECRET_KEY;
+  const url = getSupabaseUrl();
+  const key = secretKey();
   try {
     const res = await fetch(`${url}/rest/v1/albums`, {
       method: 'POST',
-      headers: {
-        apikey: key, Authorization: `Bearer ${key}`,
-        'Content-Type': 'application/json', Prefer: 'return=representation'
-      },
+      headers: sbHeaders(key, { 'Content-Type': 'application/json', Prefer: 'return=representation' }),
       body: JSON.stringify({ member, name, purchase_url: purchase_url || null })
     });
     const data = await res.json();
-    if (!res.ok) return { statusCode: res.status, body: JSON.stringify({ error: data.message || data }) };
-    return { statusCode: 200, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(Array.isArray(data) ? data[0] : data) };
+    if (!res.ok) return json(res.status, { error: data.message || data });
+    return json(200, Array.isArray(data) ? data[0] : data, { 'Content-Type': 'application/json' });
   } catch (e) {
-    return { statusCode: 500, body: JSON.stringify({ error: e.message }) };
+    return json(500, { error: e.message });
   }
 };

--- a/netlify/functions/albums-delete.js
+++ b/netlify/functions/albums-delete.js
@@ -1,42 +1,41 @@
+const { getSupabaseUrl, secretKey, sbHeaders } = require('./_shared/supabase');
+const { methodNotAllowed, invalidJson, json, parseJsonBody } = require('./_shared/responses');
+
 exports.handler = async (event) => {
-  if (event.httpMethod !== 'POST') return { statusCode: 405, body: 'Method Not Allowed' };
-  let body = {};
-  try { body = JSON.parse(event.body || '{}'); } catch {
-    return { statusCode: 400, body: JSON.stringify({ error: 'Invalid JSON' }) };
-  }
+  if (event.httpMethod !== 'POST') return methodNotAllowed();
+  const parsed = parseJsonBody(event);
+  if (!parsed.ok) return invalidJson();
+  const body = parsed.body;
   const { password, id } = body;
   if (password !== process.env.ADMIN_PASSWORD)
-    return { statusCode: 401, body: JSON.stringify({ error: 'Unauthorized' }) };
+    return json(401, { error: 'Unauthorized' });
   if (!id)
-    return { statusCode: 400, body: JSON.stringify({ error: 'id required' }) };
+    return json(400, { error: 'id required' });
 
-  const url = process.env.SUPABASE_URL;
-  const key = process.env.SUPABASE_SECRET_KEY;
+  const url = getSupabaseUrl();
+  const key = secretKey();
   try {
     // アルバム曲のalbum_idをnullに戻す
     const patchRes = await fetch(`${url}/rest/v1/videos?album_id=eq.${id}`, {
       method: 'PATCH',
-      headers: {
-        apikey: key, Authorization: `Bearer ${key}`,
-        'Content-Type': 'application/json', Prefer: 'return=minimal'
-      },
+      headers: sbHeaders(key, { 'Content-Type': 'application/json', Prefer: 'return=minimal' }),
       body: JSON.stringify({ album_id: null })
     });
     if (!patchRes.ok) {
       const t = await patchRes.text();
-      return { statusCode: patchRes.status, body: JSON.stringify({ error: 'album_id解除に失敗: ' + t }) };
+      return json(patchRes.status, { error: 'album_id解除に失敗: ' + t });
     }
     // アルバム削除
     const res = await fetch(`${url}/rest/v1/albums?id=eq.${id}`, {
       method: 'DELETE',
-      headers: { apikey: key, Authorization: `Bearer ${key}`, Prefer: 'return=minimal' }
+      headers: sbHeaders(key, { Prefer: 'return=minimal' })
     });
     if (!res.ok) {
       const t = await res.text();
-      return { statusCode: res.status, body: JSON.stringify({ error: t }) };
+      return json(res.status, { error: t });
     }
-    return { statusCode: 200, body: JSON.stringify({ ok: true }) };
+    return json(200, { ok: true });
   } catch (e) {
-    return { statusCode: 500, body: JSON.stringify({ error: e.message }) };
+    return json(500, { error: e.message });
   }
 };

--- a/netlify/functions/albums-get.js
+++ b/netlify/functions/albums-get.js
@@ -1,11 +1,13 @@
+const { readKey, sbHeaders } = require('./_shared/supabase');
+
 exports.handler = async () => {
   const url = process.env.SUPABASE_URL;
   // 読み取り専用: anon key を使用（RLS で制御）
-  // フォールバック: SUPABASE_ANON_KEY 未設定時は SECRET_KEY を使用
-  const key = process.env.SUPABASE_ANON_KEY || process.env.SUPABASE_SECRET_KEY;
+  // フォールバック: SUPABASE_ANON_KEY 未設定時は SECRET_KEY を使用（readKey）
+  const key = readKey();
   try {
     const res = await fetch(`${url}/rest/v1/albums?select=*&order=created_at.asc`, {
-      headers: { apikey: key, Authorization: `Bearer ${key}` }
+      headers: sbHeaders(key)
     });
     const data = await res.json();
     return {

--- a/netlify/functions/albums-update.js
+++ b/netlify/functions/albums-update.js
@@ -1,38 +1,37 @@
+const { getSupabaseUrl, secretKey, sbHeaders } = require('./_shared/supabase');
+const { methodNotAllowed, invalidJson, json, parseJsonBody } = require('./_shared/responses');
+
 exports.handler = async (event) => {
-  if (event.httpMethod !== 'POST') return { statusCode: 405, body: 'Method Not Allowed' };
-  let body = {};
-  try { body = JSON.parse(event.body || '{}'); } catch(e) { return { statusCode: 400, body: JSON.stringify({ error: 'Invalid JSON' }) }; }
+  if (event.httpMethod !== 'POST') return methodNotAllowed();
+  const parsed = parseJsonBody(event);
+  if (!parsed.ok) return invalidJson();
+  const body = parsed.body;
   const { password, id, name, purchase_url, is_sold_out, status_updated_at } = body;
-  if (password !== process.env.ADMIN_PASSWORD) return { statusCode: 401, body: JSON.stringify({ error: 'パスワードが違います' }) };
-  if (!id) return { statusCode: 400, body: JSON.stringify({ error: 'idが必要です' }) };
+  if (password !== process.env.ADMIN_PASSWORD) return json(401, { error: 'パスワードが違います' });
+  if (!id) return json(400, { error: 'idが必要です' });
   // ホワイトリスト: 更新を許可するフィールドのみ抽出
   const fields = {};
   if (name !== undefined) fields.name = name;
   if (purchase_url !== undefined) fields.purchase_url = purchase_url;
   if (is_sold_out !== undefined) fields.is_sold_out = is_sold_out;
   if (status_updated_at !== undefined) fields.status_updated_at = status_updated_at;
-  if (Object.keys(fields).length === 0) return { statusCode: 400, body: JSON.stringify({ error: '更新するフィールドがありません' }) };
-  const supaUrl = process.env.SUPABASE_URL;
-  const supaKey = process.env.SUPABASE_SECRET_KEY;
-  if (!supaUrl || !supaKey) return { statusCode: 500, body: JSON.stringify({ error: 'Supabase env vars missing' }) };
+  if (Object.keys(fields).length === 0) return json(400, { error: '更新するフィールドがありません' });
+  const supaUrl = getSupabaseUrl();
+  const supaKey = secretKey();
+  if (!supaUrl || !supaKey) return json(500, { error: 'Supabase env vars missing' });
   try {
     const res = await fetch(`${supaUrl}/rest/v1/albums?id=eq.${id}`, {
       method: 'PATCH',
-      headers: {
-        apikey: supaKey,
-        Authorization: `Bearer ${supaKey}`,
-        'Content-Type': 'application/json',
-        Prefer: 'return=representation',
-      },
+      headers: sbHeaders(supaKey, { 'Content-Type': 'application/json', Prefer: 'return=representation' }),
       body: JSON.stringify(fields),
     });
     const text = await res.text();
-    if (!text) return { statusCode: 500, body: JSON.stringify({ error: 'Empty response' }) };
+    if (!text) return json(500, { error: 'Empty response' });
     let data;
-    try { data = JSON.parse(text); } catch(e) { return { statusCode: 500, body: JSON.stringify({ error: 'Parse error', raw: text.slice(0,200) }) }; }
-    if (!res.ok) return { statusCode: res.status, body: JSON.stringify({ error: data.message || text }) };
-    return { statusCode: 200, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(Array.isArray(data) ? data[0] : data) };
+    try { data = JSON.parse(text); } catch(e) { return json(500, { error: 'Parse error', raw: text.slice(0,200) }); }
+    if (!res.ok) return json(res.status, { error: data.message || text });
+    return json(200, Array.isArray(data) ? data[0] : data, { 'Content-Type': 'application/json' });
   } catch(e) {
-    return { statusCode: 500, body: JSON.stringify({ error: e.message }) };
+    return json(500, { error: e.message });
   }
 };

--- a/netlify/functions/auth-check.js
+++ b/netlify/functions/auth-check.js
@@ -1,14 +1,17 @@
+const { methodNotAllowed, invalidJson, json, parseJsonBody } = require('./_shared/responses');
+
 exports.handler = async (event) => {
   if (event.httpMethod !== 'POST') {
-    return { statusCode: 405, body: 'Method Not Allowed' };
+    return methodNotAllowed();
   }
-  let body = {};
-  try { body = JSON.parse(event.body || '{}'); } catch(e) {
-    return { statusCode: 400, body: JSON.stringify({ error: 'Invalid JSON' }) };
+  const parsed = parseJsonBody(event);
+  if (!parsed.ok) {
+    return invalidJson();
   }
+  const body = parsed.body;
   const { password } = body;
   if (password !== process.env.ADMIN_PASSWORD) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'パスワードが違います' }) };
+    return json(401, { error: 'パスワードが違います' });
   }
-  return { statusCode: 200, body: JSON.stringify({ ok: true }) };
+  return json(200, { ok: true });
 };

--- a/netlify/functions/ingest-youtube.js
+++ b/netlify/functions/ingest-youtube.js
@@ -5,6 +5,11 @@
 // 自動publish禁止 — 取り込みは常に status='pending' 止まり
 // ═══════════════════════════════════════════════════════════════
 
+const { getSupabaseUrl, secretKey, sbHeaders: buildSbHeaders, sbFetch, fetchAllVideoRows } = require('./_shared/supabase');
+// URLからYouTube videoId（11文字）を抽出（playlist-import.js / admin-query.jsと共通）
+// 注: playlistItems.list の1ページ50件取得は意図的仕様のため fetchAllPlaylistItems は使わない
+const { ytId } = require('./_shared/yt');
+
 // ── キーワード定数辞書 ──
 const SHORTS_KEYWORDS = ['#shorts'];
 const LIVE_KEYWORDS = [
@@ -38,11 +43,6 @@ function parseDuration(iso) {
   if (!m) return null;
   return (parseInt(m[1] || 0) * 3600) + (parseInt(m[2] || 0) * 60) + parseInt(m[3] || 0);
 }
-
-/**
- * YouTube URL から videoId を抽出（null安全）
- */
-function ytId(url){ if(!url) return null; const m=String(url).match(/(?:v=|youtu\.be\/|embed\/)([a-zA-Z0-9_-]{11})/); return m?m[1]:null; }
 
 /**
  * タイトル + description からcontent_typeを判定
@@ -103,22 +103,12 @@ function detectCoverTag(title) {
   return COVER_KEYWORDS.some(k => t.includes(k)) ? 'Covered' : null;
 }
 
-/**
- * Supabase fetch ラッパー（エラーはそのままthrow）
- */
-async function sbFetch(url, options) {
-  const res = await fetch(url, options);
-  if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    throw new Error(`Supabase ${res.status}: ${text.slice(0, 300)}`);
-  }
-  return res.json();
-}
+// Supabase fetch ラッパーは _shared/supabase.js の sbFetch を errSlice:300 で使用（現行の切り詰め長を維持）
 
 // ── メインハンドラ ──
 exports.handler = async (event) => {
-  const SUPABASE_URL = process.env.SUPABASE_URL;
-  const SUPABASE_KEY = process.env.SUPABASE_SECRET_KEY;
+  const SUPABASE_URL = getSupabaseUrl();
+  const SUPABASE_KEY = secretKey();
   const YT_KEY = process.env.YOUTUBE_API_KEY;
   const ADMIN_PW = process.env.ADMIN_PASSWORD;
 
@@ -143,12 +133,10 @@ exports.handler = async (event) => {
     }
   }
 
-  const sbHeaders = {
-    apikey: SUPABASE_KEY,
-    Authorization: `Bearer ${SUPABASE_KEY}`,
+  const sbHeaders = buildSbHeaders(SUPABASE_KEY, {
     'Content-Type': 'application/json',
     Prefer: 'return=representation'
-  };
+  });
 
   const results = [];
 
@@ -156,7 +144,8 @@ exports.handler = async (event) => {
     // (a) ingest_channels から enabled=true を取得
     const channels = await sbFetch(
       `${SUPABASE_URL}/rest/v1/ingest_channels?select=*&enabled=eq.true`,
-      { headers: sbHeaders }
+      { headers: sbHeaders },
+      { errSlice: 300 }
     );
     if (!Array.isArray(channels) || channels.length === 0) {
       return { statusCode: 200, body: JSON.stringify({ message: '有効なチャンネルがありません', results }) };
@@ -164,12 +153,11 @@ exports.handler = async (event) => {
 
     // (e) Supabase で既存videoId突合（チャンネル横断・ループ外で1回だけfetch）
     // pending含む全件 — status不問でないと重複取りこぼし
-    // 憲法5: 1,000件超は limit=10000&offset=0 を明示（デフォルトLIMIT 1000でsilent drop）
-    const existingRows = await sbFetch(
-      `${SUPABASE_URL}/rest/v1/videos?select=url&limit=10000&offset=0`,
-      { headers: { apikey: SUPABASE_KEY, Authorization: `Bearer ${SUPABASE_KEY}` } }
+    // 憲法5: 1,000件超は limit=10000&offset=0 を明示（fetchAllVideoRows。デフォルトLIMIT 1000でsilent drop）
+    const { rows: existingRows, overflow } = await fetchAllVideoRows(
+      SUPABASE_URL, SUPABASE_KEY, 'url', { throwOnHttpError: true, errSlice: 300 }
     );
-    if (Array.isArray(existingRows) && existingRows.length >= 10000) {
+    if (overflow) {
       console.error('videos件数が全件fetch上限(10000)に到達。dedup不完全のため取り込み中止。ページング実装が必要。');
       return { statusCode: 500, body: JSON.stringify({ error: 'videos件数が上限に到達。ページング未実装のため安全のため中止。', count: existingRows.length }) };
     }

--- a/netlify/functions/observer-link-exchange.js
+++ b/netlify/functions/observer-link-exchange.js
@@ -1,4 +1,5 @@
-const crypto = require('crypto');
+const { serviceKey, sbFetch } = require('./_shared/supabase');
+const { getClientHash } = require('./_shared/client-hash');
 
 const DAILY_LIMIT = 10;
 const VALID_MOODS = ['Morning', 'Night', 'Rain', 'Walk', 'Work', 'Chill'];
@@ -15,21 +16,7 @@ function resp(status, body) {
   };
 }
 
-function getClientHash(event) {
-  // Use Netlify's reliable client IP header, fall back to x-forwarded-for
-  const ip = (event.headers['x-nf-client-connection-ip']
-    || (event.headers['x-forwarded-for'] || '127.0.0.1').split(',')[0]).trim();
-  return crypto.createHash('sha256').update(ip).digest('hex');
-}
-
-async function sbFetch(url, options) {
-  const res = await fetch(url, options);
-  if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    throw new Error(`Supabase ${res.status}: ${text.slice(0, 200)}`);
-  }
-  return res.json();
-}
+// getClientHash / sbFetch（errSlice既定=200）は _shared に集約（実装は現行と同一）
 
 // videos取得専用: migration未適用で status 列が存在しない場合（PostgREST 42703）は
 // status=eq.published フィルタなしで1回だけ再試行する。
@@ -63,7 +50,7 @@ exports.handler = async (event) => {
   }
 
   const url = process.env.SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SECRET_KEY;
+  const key = serviceKey();
   const sbHeaders = {
     apikey: key,
     Authorization: `Bearer ${key}`,

--- a/netlify/functions/observer-link-result.js
+++ b/netlify/functions/observer-link-result.js
@@ -1,3 +1,5 @@
+const { serviceKey } = require('./_shared/supabase');
+
 // videos取得専用: migration未適用で status 列が存在しない場合（PostgREST 42703）は
 // status=eq.published フィルタなしで1回だけ再試行する。
 // migration適用前は status 列が存在しない = pending 行も存在し得ないため、
@@ -21,7 +23,7 @@ exports.handler = async (event) => {
   }
 
   const url = process.env.SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SECRET_KEY;
+  const key = serviceKey();
   const sbHeaders = { apikey: key, Authorization: `Bearer ${key}` };
 
   const id = event.queryStringParameters?.id;

--- a/netlify/functions/playlist-import.js
+++ b/netlify/functions/playlist-import.js
@@ -1,43 +1,35 @@
-// URLからYouTube videoId（11文字）を抽出（ingest-youtube.jsと同一）
-function ytId(url){ if(!url) return null; const m=String(url).match(/(?:v=|youtu\.be\/|embed\/)([a-zA-Z0-9_-]{11})/); return m?m[1]:null; }
+const { getSupabaseUrl, secretKey, sbHeaders, fetchAllVideoRows } = require('./_shared/supabase');
+const { methodNotAllowed, invalidJson, json, parseJsonBody } = require('./_shared/responses');
+// URLからYouTube videoId（11文字）を抽出 / プレイリスト全件取得（ingest-youtube.js / admin-query.jsと共通）
+const { ytId, fetchAllPlaylistItems } = require('./_shared/yt');
 
 exports.handler = async (event) => {
-  if (event.httpMethod !== 'POST') return { statusCode: 405, body: 'Method Not Allowed' };
-  let body;
-  try { body = JSON.parse(event.body || '{}'); } catch { return { statusCode: 400, body: JSON.stringify({ error: 'Invalid JSON' }) }; }
+  if (event.httpMethod !== 'POST') return methodNotAllowed();
+  const parsed = parseJsonBody(event);
+  if (!parsed.ok) return invalidJson();
+  const body = parsed.body;
   const { playlistId, member, tags, password, album_id } = body;
-  if (!password || password !== process.env.ADMIN_PASSWORD) return { statusCode: 401, body: JSON.stringify({ error: 'Unauthorized' }) };
-  if (!playlistId || !member) return { statusCode: 400, body: JSON.stringify({ error: 'playlistId and member required' }) };
+  if (!password || password !== process.env.ADMIN_PASSWORD) return json(401, { error: 'Unauthorized' });
+  if (!playlistId || !member) return json(400, { error: 'playlistId and member required' });
   // YouTube playlist ID: "PL" + 英数字・ハイフン・アンダースコア（16〜64文字）
   if (!/^PL[a-zA-Z0-9_-]{16,64}$/.test(playlistId)) {
-    return { statusCode: 400, body: JSON.stringify({ error: 'Invalid playlist ID format' }) };
+    return json(400, { error: 'Invalid playlist ID format' });
   }
   const apiKey = process.env.YOUTUBE_API_KEY;
-  const supaUrl = process.env.SUPABASE_URL;
-  const supaKey = process.env.SUPABASE_SECRET_KEY;
+  const supaUrl = getSupabaseUrl();
+  const supaKey = secretKey();
 
   // YouTubeプレイリスト全件取得（最大200件）
-  let allItems = [];
-  let pageToken = '';
-  while (true) {
-    const url = `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&maxResults=50&playlistId=${encodeURIComponent(playlistId)}&key=${apiKey}${pageToken ? '&pageToken=' + encodeURIComponent(pageToken) : ''}`;
-    const res = await fetch(url);
-    const data = await res.json();
-    if (data.error) return { statusCode: 400, body: JSON.stringify({ error: data.error.message }) };
-    const items = (data.items || []).filter(i => i.snippet.resourceId.kind === 'youtube#video');
-    allItems = allItems.concat(items);
-    if (data.nextPageToken && allItems.length < 200) { pageToken = data.nextPageToken; } else break;
-  }
+  const pl = await fetchAllPlaylistItems(playlistId, apiKey);
+  if (pl.error) return json(400, { error: pl.error.message });
+  const allItems = pl.items;
 
   // 既存動画を全件取得（url と id を取得）
-  // 憲法5: PostgRESTデフォルトLIMIT1000のsilent dropを防ぐためlimit/offset明示
-  const existRes = await fetch(`${supaUrl}/rest/v1/videos?select=id,url&limit=10000&offset=0`, {
-    headers: { apikey: supaKey, Authorization: `Bearer ${supaKey}` }
-  });
-  const existData = await existRes.json();
+  // 憲法5: PostgRESTデフォルトLIMIT1000のsilent dropを防ぐためlimit/offset明示（fetchAllVideoRows）
+  const { rows: existData, overflow } = await fetchAllVideoRows(supaUrl, supaKey, 'id,url');
   // 上限到達時は突合不完全＝重複公開の恐れがあるため中止
-  if (Array.isArray(existData) && existData.length >= 10000) {
-    return { statusCode: 500, body: JSON.stringify({ error: 'videos件数が全件fetch上限(10000)に到達。ページング未実装のため安全のため中止。', count: existData.length }) };
+  if (overflow) {
+    return json(500, { error: 'videos件数が全件fetch上限(10000)に到達。ページング未実装のため安全のため中止。', count: existData.length });
   }
   const existingMap = new Map();
   (existData || []).forEach(v => { const vid = ytId(v.url); if (vid) existingMap.set(vid, v.id); });
@@ -70,7 +62,7 @@ exports.handler = async (event) => {
     for (const id of toLink) {
       await fetch(`${supaUrl}/rest/v1/videos?id=eq.${id}`, {
         method: 'PATCH',
-        headers: { apikey: supaKey, Authorization: `Bearer ${supaKey}`, 'Content-Type': 'application/json', Prefer: 'return=minimal' },
+        headers: sbHeaders(supaKey, { 'Content-Type': 'application/json', Prefer: 'return=minimal' }),
         body: JSON.stringify({ album_id })
       });
       linked++;
@@ -78,19 +70,19 @@ exports.handler = async (event) => {
   }
 
   if (toInsert.length === 0) {
-    return { statusCode: 200, body: JSON.stringify({ inserted: 0, skipped: allItems.length - linked, linked, message: `新規追加なし（既存${linked}件をアルバムに紐付け）` }) };
+    return json(200, { inserted: 0, skipped: allItems.length - linked, linked, message: `新規追加なし（既存${linked}件をアルバムに紐付け）` });
   }
 
   const insertRes = await fetch(`${supaUrl}/rest/v1/videos`, {
     method: 'POST',
-    headers: { apikey: supaKey, Authorization: `Bearer ${supaKey}`, 'Content-Type': 'application/json', Prefer: 'return=minimal' },
+    headers: sbHeaders(supaKey, { 'Content-Type': 'application/json', Prefer: 'return=minimal' }),
     body: JSON.stringify(toInsert)
   });
-  if (!insertRes.ok) { const errText = await insertRes.text(); return { statusCode: 500, body: JSON.stringify({ error: errText }) }; }
-  return { statusCode: 200, body: JSON.stringify({
+  if (!insertRes.ok) { const errText = await insertRes.text(); return json(500, { error: errText }); }
+  return json(200, {
     inserted: toInsert.length,
     skipped: allItems.length - toInsert.length - linked,
     linked,
     message: `${toInsert.length}件追加、${linked}件を既存曲としてアルバムに紐付け、${allItems.length - toInsert.length - linked}件スキップ`
-  }) };
+  });
 };

--- a/netlify/functions/videos-add.js
+++ b/netlify/functions/videos-add.js
@@ -1,58 +1,53 @@
+const { getSupabaseUrl, secretKey, sbHeaders } = require('./_shared/supabase');
+const { methodNotAllowed, invalidJson, json, parseJsonBody } = require('./_shared/responses');
+
 exports.handler = async (event) => {
   if (event.httpMethod !== 'POST') {
-    return { statusCode: 405, body: 'Method Not Allowed' };
+    return methodNotAllowed();
   }
 
-  let body = {};
-  try { body = JSON.parse(event.body || '{}'); } catch(e) {
-    return { statusCode: 400, body: JSON.stringify({ error: 'Invalid JSON' }) };
+  const parsed = parseJsonBody(event);
+  if (!parsed.ok) {
+    return invalidJson();
   }
+  const body = parsed.body;
 
   const { password, member, title, tags, date, url, note, spotify_url, album_id } = body;
 
   if (password !== process.env.ADMIN_PASSWORD) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'パスワードが違います' }) };
+    return json(401, { error: 'パスワードが違います' });
   }
 
-  const supaUrl = process.env.SUPABASE_URL;
-  const supaKey = process.env.SUPABASE_SECRET_KEY;
+  const supaUrl = getSupabaseUrl();
+  const supaKey = secretKey();
 
   if (!supaUrl || !supaKey) {
-    return { statusCode: 500, body: JSON.stringify({ error: 'Supabase env vars missing' }) };
+    return json(500, { error: 'Supabase env vars missing' });
   }
 
   try {
     const res = await fetch(`${supaUrl}/rest/v1/videos`, {
       method: 'POST',
-      headers: {
-        apikey: supaKey,
-        Authorization: `Bearer ${supaKey}`,
-        'Content-Type': 'application/json',
-        Prefer: 'return=representation',
-      },
+      headers: sbHeaders(supaKey, { 'Content-Type': 'application/json', Prefer: 'return=representation' }),
       body: JSON.stringify({ member, title, tags: tags || '', date, url, note, spotify_url: spotify_url || null, album_id: album_id || null }),
     });
 
     const text = await res.text();
     if (!text) {
-      return { statusCode: 500, body: JSON.stringify({ error: 'Supabase returned empty response', status: res.status }) };
+      return json(500, { error: 'Supabase returned empty response', status: res.status });
     }
 
     let data;
     try { data = JSON.parse(text); } catch(e) {
-      return { statusCode: 500, body: JSON.stringify({ error: 'Supabase parse error', raw: text.slice(0, 200) }) };
+      return json(500, { error: 'Supabase parse error', raw: text.slice(0, 200) });
     }
 
     if (!res.ok) {
-      return { statusCode: res.status, body: JSON.stringify({ error: data.message || data.error || text }) };
+      return json(res.status, { error: data.message || data.error || text });
     }
 
-    return {
-      statusCode: 200,
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(Array.isArray(data) ? data[0] : data),
-    };
+    return json(200, Array.isArray(data) ? data[0] : data, { 'Content-Type': 'application/json' });
   } catch (e) {
-    return { statusCode: 500, body: JSON.stringify({ error: e.message }) };
+    return json(500, { error: e.message });
   }
 };

--- a/netlify/functions/videos-delete.js
+++ b/netlify/functions/videos-delete.js
@@ -1,44 +1,42 @@
+const { getSupabaseUrl, secretKey, sbHeaders } = require('./_shared/supabase');
+const { methodNotAllowed, invalidJson, json, parseJsonBody } = require('./_shared/responses');
+
 exports.handler = async (event) => {
   if (event.httpMethod !== 'POST') {
-    return { statusCode: 405, body: 'Method Not Allowed' };
+    return methodNotAllowed();
   }
 
-  let body;
-  try {
-    body = JSON.parse(event.body || '{}');
-  } catch {
-    return { statusCode: 400, body: JSON.stringify({ error: 'Invalid JSON' }) };
+  const parsed = parseJsonBody(event);
+  if (!parsed.ok) {
+    return invalidJson();
   }
+  const body = parsed.body;
 
   const { password, id } = body;
 
   // パスワード認証
   if (password !== process.env.ADMIN_PASSWORD) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'パスワードが違います' }) };
+    return json(401, { error: 'パスワードが違います' });
   }
 
   if (!id) {
-    return { statusCode: 400, body: JSON.stringify({ error: 'idが必要です' }) };
+    return json(400, { error: 'idが必要です' });
   }
 
-  const supaUrl = process.env.SUPABASE_URL;
-  const supaKey = process.env.SUPABASE_SECRET_KEY;
+  const supaUrl = getSupabaseUrl();
+  const supaKey = secretKey();
 
   try {
     const res = await fetch(`${supaUrl}/rest/v1/videos?id=eq.${id}`, {
       method: 'DELETE',
-      headers: {
-        apikey: supaKey,
-        Authorization: `Bearer ${supaKey}`,
-        Prefer: 'return=minimal',
-      },
+      headers: sbHeaders(supaKey, { Prefer: 'return=minimal' }),
     });
     if (!res.ok) {
       const t = await res.text();
-      return { statusCode: res.status, body: JSON.stringify({ error: t }) };
+      return json(res.status, { error: t });
     }
-    return { statusCode: 200, body: JSON.stringify({ ok: true }) };
+    return json(200, { ok: true });
   } catch (e) {
-    return { statusCode: 500, body: JSON.stringify({ error: e.message }) };
+    return json(500, { error: e.message });
   }
 };

--- a/netlify/functions/videos-get.js
+++ b/netlify/functions/videos-get.js
@@ -1,9 +1,11 @@
+const { readKey, sbHeaders } = require('./_shared/supabase');
+
 exports.handler = async () => {
   const url = process.env.SUPABASE_URL;
   // 読み取り専用: anon key を使用（RLS で制御）
-  // フォールバック: SUPABASE_ANON_KEY 未設定時は SECRET_KEY を使用
-  const key = process.env.SUPABASE_ANON_KEY || process.env.SUPABASE_SECRET_KEY;
-  const headers = { apikey: key, Authorization: `Bearer ${key}` };
+  // フォールバック: SUPABASE_ANON_KEY 未設定時は SECRET_KEY を使用（readKey）
+  const key = readKey();
+  const headers = sbHeaders(key);
 
   // 1ページ取得。migration未適用で status 列が存在しない場合（PostgREST 42703）は
   // status=eq.published フィルタなしで1回だけ再試行する。

--- a/netlify/functions/videos-update.js
+++ b/netlify/functions/videos-update.js
@@ -1,43 +1,42 @@
+const { getSupabaseUrl, secretKey, sbHeaders } = require('./_shared/supabase');
+const { methodNotAllowed, invalidJson, json, parseJsonBody } = require('./_shared/responses');
+
 exports.handler = async (event) => {
   if (event.httpMethod !== 'POST') {
-    return { statusCode: 405, body: 'Method Not Allowed' };
+    return methodNotAllowed();
   }
-  let body = {};
-  try { body = JSON.parse(event.body || '{}'); } catch(e) {
-    return { statusCode: 400, body: JSON.stringify({ error: 'Invalid JSON' }) };
+  const parsed = parseJsonBody(event);
+  if (!parsed.ok) {
+    return invalidJson();
   }
+  const body = parsed.body;
   const { password, id, member, title, tags, date, url, note, spotify_url, album_id } = body;
   if (password !== process.env.ADMIN_PASSWORD) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'パスワードが違います' }) };
+    return json(401, { error: 'パスワードが違います' });
   }
   if (!id) {
-    return { statusCode: 400, body: JSON.stringify({ error: 'idが必要です' }) };
+    return json(400, { error: 'idが必要です' });
   }
-  const supaUrl = process.env.SUPABASE_URL;
-  const supaKey = process.env.SUPABASE_SECRET_KEY;
+  const supaUrl = getSupabaseUrl();
+  const supaKey = secretKey();
   if (!supaUrl || !supaKey) {
-    return { statusCode: 500, body: JSON.stringify({ error: 'Supabase env vars missing' }) };
+    return json(500, { error: 'Supabase env vars missing' });
   }
   try {
     const res = await fetch(`${supaUrl}/rest/v1/videos?id=eq.${id}`, {
       method: 'PATCH',
-      headers: {
-        apikey: supaKey,
-        Authorization: `Bearer ${supaKey}`,
-        'Content-Type': 'application/json',
-        Prefer: 'return=representation',
-      },
+      headers: sbHeaders(supaKey, { 'Content-Type': 'application/json', Prefer: 'return=representation' }),
       body: JSON.stringify({ member, title, tags: tags || '', date, url, note, spotify_url: spotify_url || null, album_id: album_id !== undefined ? album_id : undefined }),
     });
     const text = await res.text();
-    if (!text) return { statusCode: 500, body: JSON.stringify({ error: 'Empty response' }) };
+    if (!text) return json(500, { error: 'Empty response' });
     let data;
     try { data = JSON.parse(text); } catch(e) {
-      return { statusCode: 500, body: JSON.stringify({ error: 'Parse error', raw: text.slice(0,200) }) };
+      return json(500, { error: 'Parse error', raw: text.slice(0,200) });
     }
-    if (!res.ok) return { statusCode: res.status, body: JSON.stringify({ error: data.message || text }) };
-    return { statusCode: 200, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(Array.isArray(data) ? data[0] : data) };
+    if (!res.ok) return json(res.status, { error: data.message || text });
+    return json(200, Array.isArray(data) ? data[0] : data, { 'Content-Type': 'application/json' });
   } catch(e) {
-    return { statusCode: 500, body: JSON.stringify({ error: e.message }) };
+    return json(500, { error: e.message });
   }
 };

--- a/tests/fn-snapshot/run.mjs
+++ b/tests/fn-snapshot/run.mjs
@@ -1,0 +1,130 @@
+// tests/fn-snapshot/run.mjs — Netlify Functions 入出力スナップショットハーネス（B3計画§6層1）
+//
+// 使い方:
+//   node tests/fn-snapshot/run.mjs --fn-dir netlify/functions --out /tmp/after.json
+//   node tests/fn-snapshot/run.mjs --fn-dir /tmp/vwp-b3-base/netlify/functions --out /tmp/base.json
+//   diff /tmp/base.json /tmp/after.json   # 空 = 同値性の機械保証
+//
+// 仕組み:
+//   - global.fetch をシナリオごとのルートテーブルでスタブ（PostgREST / YouTube応答をfixture化）
+//   - Date.now / new Date（引数なし）/ Math.random / env をダミー固定
+//   - 各handlerを require してモックeventで直接呼び、戻り値全体
+//     （statusCode / headers / body — headersキーの有無まで）をJSONシリアライズ保存
+//   - 送信した外向きfetch（url / method / headers / body）も記録 → DB書き込み等の副作用も比較対象
+//
+// 注意: スナップショットは前後比較専用（絶対値の正しさは層2のデプロイプレビューcurlで担保）。
+
+import { createRequire } from 'node:module';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { dirname } from 'node:path';
+
+// ── 引数 ──
+const args = process.argv.slice(2);
+function arg(name) { const i = args.indexOf(name); return i >= 0 ? args[i + 1] : null; }
+const fnDir = path.resolve(arg('--fn-dir') || 'netlify/functions');
+const out = arg('--out');
+if (!out) { console.error('usage: node run.mjs --fn-dir <functions dir> --out <snapshot file>'); process.exit(1); }
+
+// ── 決定論化: Date ──
+const RealDate = Date;
+const FIXED_NOW = new RealDate('2026-01-15T12:00:00.000Z').getTime();
+class FixedDate extends RealDate {
+  constructor(...a) { if (a.length === 0) { super(FIXED_NOW); } else { super(...a); } }
+  static now() { return FIXED_NOW; }
+}
+globalThis.Date = FixedDate;
+
+// ── 決定論化: Math.random（固定シーケンス、シナリオごとにリセット） ──
+const RAND_SEQ = [0.42, 0.17, 0.83, 0.05, 0.61, 0.29, 0.94, 0.50];
+let randIdx = 0;
+Math.random = () => RAND_SEQ[(randIdx++) % RAND_SEQ.length];
+
+// ── 決定論化: env（ダミー固定。シナリオ単位で上書き/削除可） ──
+const BASE_ENV = {
+  SUPABASE_URL: 'https://sb.example.test',
+  SUPABASE_SECRET_KEY: 'sk_secret_dummy',
+  SUPABASE_ANON_KEY: 'sk_anon_dummy',
+  SUPABASE_SERVICE_ROLE_KEY: 'sk_service_dummy',
+  YOUTUBE_API_KEY: 'yt_key_dummy',
+  ADMIN_PASSWORD: 'admin_pw_dummy',
+};
+function applyEnv(overrides = {}) {
+  const merged = { ...BASE_ENV, ...overrides };
+  for (const [k, v] of Object.entries(merged)) {
+    if (v === undefined || v === null) delete process.env[k]; else process.env[k] = v;
+  }
+}
+
+// ── fetchスタブ ──
+// route: { method?: 'GET'|'POST'|..., match: string | (url, opts) => bool, status?: number, body: any | (url, opts) => any, networkError?: string }
+function makeFetchStub(routes, calls) {
+  return async (url, opts = {}) => {
+    const u = String(url);
+    const method = opts.method || 'GET';
+    calls.push({
+      method,
+      url: u,
+      headers: opts.headers,
+      body: typeof opts.body === 'string' ? opts.body : opts.body === undefined ? undefined : String(opts.body),
+    });
+    for (const r of routes) {
+      if (r.method && r.method !== method) continue;
+      const hit = typeof r.match === 'function' ? r.match(u, opts) : u.includes(r.match);
+      if (!hit) continue;
+      if (r.networkError) throw new Error(r.networkError);
+      const status = r.status ?? 200;
+      const raw = typeof r.body === 'function' ? r.body(u, opts) : r.body;
+      const bodyText = typeof raw === 'string' ? raw : JSON.stringify(raw);
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        text: async () => bodyText,
+        json: async () => JSON.parse(bodyText),
+      };
+    }
+    // fixture不足はここで顕在化する（決定論的なので前後比較は成立するが、原則fixtureを足すこと）
+    throw new Error(`UNMATCHED_FETCH: ${method} ${u}`);
+  };
+}
+
+// ── 正規化シリアライズ（オブジェクトのキー順のみ正規化。bodyは文字列のままバイト比較） ──
+function canon(v) {
+  if (Array.isArray(v)) return v.map(canon);
+  if (v && typeof v === 'object') {
+    const o = {};
+    for (const k of Object.keys(v).sort()) {
+      if (v[k] !== undefined) o[k] = canon(v[k]);
+    }
+    return o;
+  }
+  return v;
+}
+
+// ── 実行 ──
+const require_ = createRequire(import.meta.url);
+const { scenarios } = await import('./scenarios.mjs');
+
+const results = [];
+for (const sc of scenarios) {
+  randIdx = 0;
+  applyEnv(sc.env);
+  const calls = [];
+  globalThis.fetch = makeFetchStub(sc.routes || [], calls);
+
+  let entry = { name: sc.name, fn: sc.fn };
+  try {
+    const mod = require_(path.join(fnDir, sc.fn + '.js'));
+    const ret = await mod.handler(sc.event, {});
+    entry.result = canon(ret);
+  } catch (e) {
+    entry.threw = String(e && e.message);
+  }
+  entry.calls = canon(calls);
+  results.push(entry);
+}
+applyEnv({});
+
+mkdirSync(dirname(path.resolve(out)), { recursive: true });
+writeFileSync(out, JSON.stringify(results, null, 2) + '\n');
+console.error(`wrote ${results.length} scenarios -> ${out}`);

--- a/tests/fn-snapshot/scenarios.mjs
+++ b/tests/fn-snapshot/scenarios.mjs
@@ -1,0 +1,827 @@
+// tests/fn-snapshot/scenarios.mjs — シナリオ + fixtures（B3計画§6層1）
+// 各シナリオ: { name, fn, event, routes, env? }
+// routes は run.mjs の fetchスタブ用ルートテーブル。fixture不足は UNMATCHED_FETCH で顕在化する。
+
+import crypto from 'node:crypto';
+
+const sha256 = (s) => crypto.createHash('sha256').update(s).digest('hex');
+
+// ── 固定値（run.mjs の BASE_ENV と一致させること） ──
+export const PW = 'admin_pw_dummy';
+export const SB = 'https://sb.example.test';
+const ADMIN_TOKEN = sha256(PW);
+const CLIENT_IP = '203.0.113.7';
+
+// bottle UUID（result.js の uuidRegex は hex のみ許容）
+const B_MINE = '11111111-1111-1111-1111-111111111111';
+const B_OTHER = '22222222-2222-2222-2222-222222222222';
+const B_THIRD = '33333333-3333-3333-3333-333333333333';
+
+// videos fixtures（公開済み）
+const VIDEO5 = { id: 5, title: '糸', member: 'kafu', date: '2023-01-01', url: 'https://www.youtube.com/watch?v=AAAAAAAAAAA' };
+const VIDEO9 = { id: 9, title: 'ヒバリ', member: 'rime', date: '2023-06-15', url: 'https://youtu.be/BBBBBBBBBBB' };
+const VIDEO12 = { id: 12, title: 'マザードラッグ', member: 'harusar', date: '2024-02-02', url: 'https://www.youtube.com/watch?v=DDDDDDDDDDD' };
+
+// ── イベントビルダ ──
+const post = (body, headers = {}) => ({
+  httpMethod: 'POST',
+  headers,
+  body: typeof body === 'string' ? body : JSON.stringify(body),
+});
+const get = (qs = null, headers = {}) => ({ httpMethod: 'GET', headers, queryStringParameters: qs });
+
+// ── fixtureビルダ ──
+const plVid = (videoId, title, publishedAt) => ({
+  snippet: { title, publishedAt, resourceId: { kind: 'youtube#video', videoId } },
+});
+const plNonVideo = () => ({
+  snippet: { title: 'チャンネル項目', publishedAt: '2026-01-01T00:00:00Z', resourceId: { kind: 'youtube#channel', channelId: 'UCdummy' } },
+});
+const ytDetail = (id, title, publishedAt, duration, opts = {}) => ({
+  id,
+  snippet: { title, description: opts.description || '', publishedAt },
+  contentDetails: { duration },
+  ...(opts.live ? { liveStreamingDetails: { actualStartTime: publishedAt } } : {}),
+});
+// videos全件fetch上限（10000件）到達fixture
+const bigRows = (n) => Array.from({ length: n }, (_, i) => ({
+  id: i + 1,
+  url: `https://www.youtube.com/watch?v=${String(i).padStart(11, 'Z')}`,
+}));
+const pageRows = (n, offset = 0) => Array.from({ length: n }, (_, i) => ({
+  id: offset + i + 1, title: 't' + (offset + i + 1), member: 'kafu', status: 'published',
+}));
+
+export const scenarios = [];
+
+// ═══════════════════════════════════════════════════════════════
+// 共通系: 平文405 / Invalid JSON / 認証失敗（G1 8ファイル同型パターン）
+// ═══════════════════════════════════════════════════════════════
+for (const fn of ['albums-add', 'albums-delete', 'albums-update', 'auth-check',
+  'videos-add', 'videos-delete', 'videos-update', 'playlist-import']) {
+  scenarios.push({ name: `${fn}/405-get`, fn, event: get(), routes: [] });
+  scenarios.push({ name: `${fn}/invalid-json`, fn, event: post('{bad json'), routes: [] });
+  scenarios.push({ name: `${fn}/auth-fail`, fn, event: post({ password: 'wrong_pw' }), routes: [] });
+}
+
+// ═══════════════════════════════════════════════════════════════
+// albums-add
+// ═══════════════════════════════════════════════════════════════
+scenarios.push(
+  { name: 'albums-add/missing-fields', fn: 'albums-add', event: post({ password: PW }), routes: [] },
+  {
+    name: 'albums-add/success', fn: 'albums-add',
+    event: post({ password: PW, member: 'kafu', name: '狂想', purchase_url: '' }),
+    routes: [{ method: 'POST', match: '/rest/v1/albums', status: 201, body: [{ id: 10, member: 'kafu', name: '狂想', purchase_url: null }] }],
+  },
+  {
+    name: 'albums-add/sb-error', fn: 'albums-add',
+    event: post({ password: PW, member: 'kafu', name: '狂想' }),
+    routes: [{ method: 'POST', match: '/rest/v1/albums', status: 409, body: { message: 'duplicate key value' } }],
+  },
+);
+
+// ═══════════════════════════════════════════════════════════════
+// albums-delete
+// ═══════════════════════════════════════════════════════════════
+scenarios.push(
+  { name: 'albums-delete/missing-id', fn: 'albums-delete', event: post({ password: PW }), routes: [] },
+  {
+    name: 'albums-delete/success', fn: 'albums-delete',
+    event: post({ password: PW, id: 5 }),
+    routes: [
+      { method: 'PATCH', match: 'videos?album_id=eq.5', status: 204, body: '' },
+      { method: 'DELETE', match: 'albums?id=eq.5', status: 204, body: '' },
+    ],
+  },
+  {
+    name: 'albums-delete/patch-fail', fn: 'albums-delete',
+    event: post({ password: PW, id: 5 }),
+    routes: [{ method: 'PATCH', match: 'videos?album_id=eq.5', status: 400, body: 'FK violation text' }],
+  },
+  {
+    name: 'albums-delete/delete-fail', fn: 'albums-delete',
+    event: post({ password: PW, id: 5 }),
+    routes: [
+      { method: 'PATCH', match: 'videos?album_id=eq.5', status: 204, body: '' },
+      { method: 'DELETE', match: 'albums?id=eq.5', status: 409, body: 'conflict text' },
+    ],
+  },
+);
+
+// ═══════════════════════════════════════════════════════════════
+// albums-update
+// ═══════════════════════════════════════════════════════════════
+scenarios.push(
+  { name: 'albums-update/missing-id', fn: 'albums-update', event: post({ password: PW, name: 'x' }), routes: [] },
+  { name: 'albums-update/no-fields', fn: 'albums-update', event: post({ password: PW, id: 5 }), routes: [] },
+  {
+    name: 'albums-update/env-missing', fn: 'albums-update', env: { SUPABASE_URL: undefined },
+    event: post({ password: PW, id: 5, name: 'x' }), routes: [],
+  },
+  {
+    name: 'albums-update/success', fn: 'albums-update',
+    event: post({ password: PW, id: 5, name: '狂想（新装版）', is_sold_out: true }),
+    routes: [{ method: 'PATCH', match: 'albums?id=eq.5', status: 200, body: [{ id: 5, name: '狂想（新装版）', is_sold_out: true }] }],
+  },
+  {
+    name: 'albums-update/sb-error', fn: 'albums-update',
+    event: post({ password: PW, id: 5, name: 'x' }),
+    routes: [{ method: 'PATCH', match: 'albums?id=eq.5', status: 400, body: { message: 'invalid input' } }],
+  },
+  {
+    name: 'albums-update/empty-response', fn: 'albums-update',
+    event: post({ password: PW, id: 5, name: 'x' }),
+    routes: [{ method: 'PATCH', match: 'albums?id=eq.5', status: 200, body: '' }],
+  },
+  {
+    name: 'albums-update/parse-error', fn: 'albums-update',
+    event: post({ password: PW, id: 5, name: 'x' }),
+    routes: [{ method: 'PATCH', match: 'albums?id=eq.5', status: 200, body: 'not-json-at-all' }],
+  },
+);
+
+// ═══════════════════════════════════════════════════════════════
+// auth-check
+// ═══════════════════════════════════════════════════════════════
+scenarios.push(
+  { name: 'auth-check/success', fn: 'auth-check', event: post({ password: PW }), routes: [] },
+);
+
+// ═══════════════════════════════════════════════════════════════
+// videos-add
+// ═══════════════════════════════════════════════════════════════
+scenarios.push(
+  {
+    name: 'videos-add/env-missing', fn: 'videos-add', env: { SUPABASE_URL: undefined },
+    event: post({ password: PW, member: 'kafu', title: '新曲' }), routes: [],
+  },
+  {
+    name: 'videos-add/success', fn: 'videos-add',
+    event: post({ password: PW, member: 'kafu', title: '新曲', tags: '', date: '2026-01-01', url: VIDEO5.url, note: '', spotify_url: '', album_id: null }),
+    routes: [{ method: 'POST', match: '/rest/v1/videos', status: 201, body: [{ id: 101, member: 'kafu', title: '新曲' }] }],
+  },
+  {
+    name: 'videos-add/sb-error', fn: 'videos-add',
+    event: post({ password: PW, member: 'kafu', title: '新曲', date: '2026-01-01', url: VIDEO5.url }),
+    routes: [{ method: 'POST', match: '/rest/v1/videos', status: 400, body: { message: 'null value in column' } }],
+  },
+  {
+    name: 'videos-add/empty-response', fn: 'videos-add',
+    event: post({ password: PW, member: 'kafu', title: '新曲', date: '2026-01-01', url: VIDEO5.url }),
+    routes: [{ method: 'POST', match: '/rest/v1/videos', status: 200, body: '' }],
+  },
+  {
+    name: 'videos-add/parse-error', fn: 'videos-add',
+    event: post({ password: PW, member: 'kafu', title: '新曲', date: '2026-01-01', url: VIDEO5.url }),
+    routes: [{ method: 'POST', match: '/rest/v1/videos', status: 200, body: 'garbage response text' }],
+  },
+);
+
+// ═══════════════════════════════════════════════════════════════
+// videos-delete
+// ═══════════════════════════════════════════════════════════════
+scenarios.push(
+  { name: 'videos-delete/missing-id', fn: 'videos-delete', event: post({ password: PW }), routes: [] },
+  {
+    name: 'videos-delete/success', fn: 'videos-delete',
+    event: post({ password: PW, id: 7 }),
+    routes: [{ method: 'DELETE', match: 'videos?id=eq.7', status: 204, body: '' }],
+  },
+  {
+    name: 'videos-delete/sb-error', fn: 'videos-delete',
+    event: post({ password: PW, id: 7 }),
+    routes: [{ method: 'DELETE', match: 'videos?id=eq.7', status: 409, body: 'FK constraint text' }],
+  },
+);
+
+// ═══════════════════════════════════════════════════════════════
+// videos-update
+// ═══════════════════════════════════════════════════════════════
+scenarios.push(
+  { name: 'videos-update/missing-id', fn: 'videos-update', event: post({ password: PW, title: 'x' }), routes: [] },
+  {
+    name: 'videos-update/env-missing', fn: 'videos-update', env: { SUPABASE_URL: undefined },
+    event: post({ password: PW, id: 7, title: 'x' }), routes: [],
+  },
+  {
+    name: 'videos-update/success', fn: 'videos-update',
+    event: post({ password: PW, id: 7, member: 'rime', title: '改題', tags: 'MV', date: '2026-01-02', url: VIDEO9.url, note: 'メモ', spotify_url: '', album_id: 3 }),
+    routes: [{ method: 'PATCH', match: 'videos?id=eq.7', status: 200, body: [{ id: 7, member: 'rime', title: '改題' }] }],
+  },
+  {
+    name: 'videos-update/sb-error', fn: 'videos-update',
+    event: post({ password: PW, id: 7, title: 'x' }),
+    routes: [{ method: 'PATCH', match: 'videos?id=eq.7', status: 400, body: { message: 'check constraint' } }],
+  },
+  {
+    name: 'videos-update/parse-error', fn: 'videos-update',
+    event: post({ password: PW, id: 7, title: 'x' }),
+    routes: [{ method: 'PATCH', match: 'videos?id=eq.7', status: 200, body: 'oops not json' }],
+  },
+);
+
+// ═══════════════════════════════════════════════════════════════
+// playlist-import（standalone）
+// ═══════════════════════════════════════════════════════════════
+// プレイリストfixture: page1(新規A/既存C/動画以外) → page2(新規B/バッチ内重複A)
+const PL_ID = 'PLabcdefghijklmnop';
+const plRoutesTwoPages = [
+  {
+    match: (u) => u.includes('playlistItems') && u.includes(PL_ID) && u.includes('pageToken=PT2'),
+    body: { items: [plVid('BBBBBBBBBBB', '新曲B', '2026-01-03T00:00:00Z'), plVid('AAAAAAAAAAA', '新曲A（重複）', '2026-01-02T00:00:00Z')] },
+  },
+  {
+    match: (u) => u.includes('playlistItems') && u.includes(PL_ID) && !u.includes('pageToken'),
+    body: { items: [plVid('AAAAAAAAAAA', '新曲A', '2026-01-02T00:00:00Z'), plVid('CCCCCCCCCCC', '既存C', '2026-01-01T00:00:00Z'), plNonVideo()], nextPageToken: 'PT2' },
+  },
+];
+const existingC = [{ id: 300, url: 'https://youtu.be/CCCCCCCCCCC' }];
+
+scenarios.push(
+  { name: 'playlist-import/missing-fields', fn: 'playlist-import', event: post({ password: PW }), routes: [] },
+  { name: 'playlist-import/invalid-playlist-id', fn: 'playlist-import', event: post({ password: PW, playlistId: 'XX', member: 'kafu' }), routes: [] },
+  {
+    name: 'playlist-import/yt-error', fn: 'playlist-import',
+    event: post({ password: PW, playlistId: PL_ID, member: 'kafu' }),
+    routes: [{ match: 'playlistItems', body: { error: { message: 'quota exceeded' } } }],
+  },
+  {
+    name: 'playlist-import/yt-error-no-message', fn: 'playlist-import',
+    event: post({ password: PW, playlistId: PL_ID, member: 'kafu' }),
+    routes: [{ match: 'playlistItems', body: { error: { code: 403 } } }],
+  },
+  {
+    name: 'playlist-import/success-dedup-linked', fn: 'playlist-import',
+    event: post({ password: PW, playlistId: PL_ID, member: 'kafu', tags: 'MV', album_id: 55 }),
+    routes: [
+      ...plRoutesTwoPages,
+      { method: 'GET', match: 'videos?select=id,url&limit=10000&offset=0', body: existingC },
+      { method: 'PATCH', match: 'videos?id=eq.300', status: 204, body: '' },
+      { method: 'POST', match: '/rest/v1/videos', status: 201, body: '' },
+    ],
+  },
+  {
+    name: 'playlist-import/success-no-album', fn: 'playlist-import',
+    event: post({ password: PW, playlistId: PL_ID, member: 'kafu' }),
+    routes: [
+      ...plRoutesTwoPages,
+      { method: 'GET', match: 'videos?select=id,url&limit=10000&offset=0', body: existingC },
+      { method: 'POST', match: '/rest/v1/videos', status: 201, body: '' },
+    ],
+  },
+  {
+    name: 'playlist-import/no-new-linked-only', fn: 'playlist-import',
+    event: post({ password: PW, playlistId: PL_ID, member: 'kafu', album_id: 55 }),
+    routes: [
+      { match: 'playlistItems', body: { items: [plVid('CCCCCCCCCCC', '既存C', '2026-01-01T00:00:00Z')] } },
+      { method: 'GET', match: 'videos?select=id,url&limit=10000&offset=0', body: existingC },
+      { method: 'PATCH', match: 'videos?id=eq.300', status: 204, body: '' },
+    ],
+  },
+  {
+    name: 'playlist-import/overflow-guard', fn: 'playlist-import',
+    event: post({ password: PW, playlistId: PL_ID, member: 'kafu' }),
+    routes: [
+      { match: 'playlistItems', body: { items: [plVid('AAAAAAAAAAA', '新曲A', '2026-01-02T00:00:00Z')] } },
+      { method: 'GET', match: 'videos?select=id,url&limit=10000&offset=0', body: () => bigRows(10000) },
+    ],
+  },
+  {
+    name: 'playlist-import/insert-fail', fn: 'playlist-import',
+    event: post({ password: PW, playlistId: PL_ID, member: 'kafu' }),
+    routes: [
+      { match: 'playlistItems', body: { items: [plVid('AAAAAAAAAAA', '新曲A', '2026-01-02T00:00:00Z')] } },
+      { method: 'GET', match: 'videos?select=id,url&limit=10000&offset=0', body: [] },
+      { method: 'POST', match: '/rest/v1/videos', status: 500, body: 'insert exploded' },
+    ],
+  },
+);
+
+// ═══════════════════════════════════════════════════════════════
+// admin-auth
+// ═══════════════════════════════════════════════════════════════
+scenarios.push(
+  { name: 'admin-auth/options', fn: 'admin-auth', event: { httpMethod: 'OPTIONS', headers: {} }, routes: [] },
+  { name: 'admin-auth/405-get', fn: 'admin-auth', event: get(), routes: [] },
+  { name: 'admin-auth/wrong-password', fn: 'admin-auth', event: post({ password: 'wrong_pw' }), routes: [] },
+  { name: 'admin-auth/success', fn: 'admin-auth', event: post({ password: PW }), routes: [] },
+  { name: 'admin-auth/malformed', fn: 'admin-auth', event: post('not json'), routes: [] },
+);
+
+// ═══════════════════════════════════════════════════════════════
+// admin-query
+// ═══════════════════════════════════════════════════════════════
+const AQ = { authorization: `Bearer ${ADMIN_TOKEN}` };
+scenarios.push(
+  { name: 'admin-query/options', fn: 'admin-query', event: { httpMethod: 'OPTIONS', headers: {} }, routes: [] },
+  { name: 'admin-query/405-get', fn: 'admin-query', event: get(), routes: [] },
+  { name: 'admin-query/no-auth', fn: 'admin-query', event: post({ table: 'videos' }), routes: [] },
+  { name: 'admin-query/wrong-auth', fn: 'admin-query', event: post({ table: 'videos' }, { authorization: 'Bearer deadbeef' }), routes: [] },
+  { name: 'admin-query/env-missing', fn: 'admin-query', env: { SUPABASE_URL: undefined }, event: post({ table: 'videos' }, AQ), routes: [] },
+  { name: 'admin-query/invalid-json', fn: 'admin-query', event: post('{{{', AQ), routes: [] },
+  { name: 'admin-query/query-no-table', fn: 'admin-query', event: post({}, AQ), routes: [] },
+  {
+    // 憲法5ガード: limit未指定 → limit=10000&offset=0 が外向きURLに付くこと（callsで比較）
+    name: 'admin-query/query-default-limit', fn: 'admin-query',
+    event: post({ table: 'videos', select: 'id,title' }, AQ),
+    routes: [{ method: 'GET', match: (u) => u.includes('/rest/v1/videos?select='), body: [VIDEO5, VIDEO9] }],
+  },
+  {
+    name: 'admin-query/query-full-params', fn: 'admin-query',
+    event: post({ table: 'videos', select: '*', filter: 'member=eq.kafu', order: 'date.desc', limit: '5', offset: '2' }, AQ),
+    routes: [{ method: 'GET', match: (u) => u.includes('/rest/v1/videos?select='), body: [VIDEO5] }],
+  },
+  {
+    name: 'admin-query/query-sb-error', fn: 'admin-query',
+    event: post({ table: 'nope' }, AQ),
+    routes: [{ method: 'GET', match: '/rest/v1/nope', status: 404, body: { message: 'relation "public.nope" does not exist', code: '42P01' } }],
+  },
+  { name: 'admin-query/insert-missing', fn: 'admin-query', event: post({ action: 'insert', table: 'videos' }, AQ), routes: [] },
+  {
+    name: 'admin-query/insert-success', fn: 'admin-query',
+    event: post({ action: 'insert', table: 'videos', data: { title: '新曲', member: 'koko' } }, AQ),
+    routes: [{ method: 'POST', match: '/rest/v1/videos', status: 201, body: [{ id: 200, title: '新曲', member: 'koko' }] }],
+  },
+  {
+    name: 'admin-query/insert-nonarray-error', fn: 'admin-query',
+    event: post({ action: 'insert', table: 'videos', data: { title: 'x' } }, AQ),
+    routes: [{ method: 'POST', match: '/rest/v1/videos', status: 409, body: { message: 'duplicate' } }],
+  },
+  {
+    name: 'admin-query/update-success', fn: 'admin-query',
+    event: post({ action: 'update', table: 'videos', id: 7, data: { status: 'published' } }, AQ),
+    routes: [{ method: 'PATCH', match: 'videos?id=eq.7', status: 200, body: [{ id: 7, status: 'published' }] }],
+  },
+  {
+    name: 'admin-query/delete-success', fn: 'admin-query',
+    event: post({ action: 'delete', table: 'videos', id: 7 }, AQ),
+    routes: [{ method: 'DELETE', match: 'videos?id=eq.7', status: 204, body: '' }],
+  },
+  {
+    name: 'admin-query/delete-fail', fn: 'admin-query',
+    event: post({ action: 'delete', table: 'videos', id: 7 }, AQ),
+    routes: [{ method: 'DELETE', match: 'videos?id=eq.7', status: 409, body: '' }],
+  },
+  { name: 'admin-query/youtube-invalid-id', fn: 'admin-query', event: post({ action: 'youtube', videoId: 'short' }, AQ), routes: [] },
+  { name: 'admin-query/youtube-env-missing', fn: 'admin-query', env: { YOUTUBE_API_KEY: undefined }, event: post({ action: 'youtube', videoId: 'AAAAAAAAAAA' }, AQ), routes: [] },
+  {
+    name: 'admin-query/youtube-not-found', fn: 'admin-query',
+    event: post({ action: 'youtube', videoId: 'AAAAAAAAAAA' }, AQ),
+    routes: [{ match: 'youtube/v3/videos', body: { items: [] } }],
+  },
+  {
+    name: 'admin-query/youtube-success-thumb-fallback', fn: 'admin-query',
+    event: post({ action: 'youtube', videoId: 'AAAAAAAAAAA' }, AQ),
+    routes: [{
+      match: 'youtube/v3/videos',
+      body: { items: [{ snippet: { title: '糸', publishedAt: '2023-01-01T09:00:00Z', thumbnails: { high: { url: 'https://i.ytimg.com/hi.jpg' }, default: { url: 'https://i.ytimg.com/def.jpg' } } } }] },
+    }],
+  },
+  { name: 'admin-query/unknown-action', fn: 'admin-query', event: post({ action: 'destroy-all' }, AQ), routes: [] },
+  // ── playlist-import action ──
+  { name: 'admin-query/pl-missing-fields', fn: 'admin-query', event: post({ action: 'playlist-import', playlistId: PL_ID }, AQ), routes: [] },
+  { name: 'admin-query/pl-invalid-id', fn: 'admin-query', event: post({ action: 'playlist-import', playlistId: 'XX', member: 'kafu' }, AQ), routes: [] },
+  {
+    name: 'admin-query/pl-yt-error', fn: 'admin-query',
+    event: post({ action: 'playlist-import', playlistId: PL_ID, member: 'kafu' }, AQ),
+    routes: [{ match: 'playlistItems', body: { error: { message: 'quota exceeded' } } }],
+  },
+  {
+    name: 'admin-query/pl-yt-error-no-message', fn: 'admin-query',
+    event: post({ action: 'playlist-import', playlistId: PL_ID, member: 'kafu' }, AQ),
+    routes: [{ match: 'playlistItems', body: { error: { code: 403 } } }],
+  },
+  {
+    name: 'admin-query/pl-success-dedup-linked', fn: 'admin-query',
+    event: post({ action: 'playlist-import', playlistId: PL_ID, member: 'kafu', tags: 'MV', album_id: 55 }, AQ),
+    routes: [
+      ...plRoutesTwoPages,
+      { method: 'GET', match: 'videos?select=id,url&limit=10000&offset=0', body: existingC },
+      { method: 'PATCH', match: 'videos?id=eq.300', status: 204, body: '' },
+      { method: 'POST', match: '/rest/v1/videos', status: 201, body: '' },
+    ],
+  },
+  {
+    name: 'admin-query/pl-overflow-guard', fn: 'admin-query',
+    event: post({ action: 'playlist-import', playlistId: PL_ID, member: 'kafu' }, AQ),
+    routes: [
+      { match: 'playlistItems', body: { items: [plVid('AAAAAAAAAAA', '新曲A', '2026-01-02T00:00:00Z')] } },
+      { method: 'GET', match: 'videos?select=id,url&limit=10000&offset=0', body: () => bigRows(10000) },
+    ],
+  },
+  {
+    name: 'admin-query/pl-insert-fail', fn: 'admin-query',
+    event: post({ action: 'playlist-import', playlistId: PL_ID, member: 'kafu' }, AQ),
+    routes: [
+      { match: 'playlistItems', body: { items: [plVid('AAAAAAAAAAA', '新曲A', '2026-01-02T00:00:00Z')] } },
+      { method: 'GET', match: 'videos?select=id,url&limit=10000&offset=0', body: [] },
+      { method: 'POST', match: '/rest/v1/videos', status: 500, body: 'insert exploded' },
+    ],
+  },
+);
+
+// ═══════════════════════════════════════════════════════════════
+// ingest-youtube
+// ═══════════════════════════════════════════════════════════════
+const CHANNEL = {
+  id: 77, channel_id: 'UCkafu_dummy', member_id: 'kafu', enabled: true,
+  uploads_playlist_id: 'UUkafu_dummy',
+  last_video_published_at: '2026-01-10T00:00:00Z', last_checked_at: '2026-01-14T00:00:00Z',
+};
+const INGEST_PLAYLIST = {
+  items: [
+    plVid('sng_kafu_01', '花譜 - 春の歌【オリジナルMV】', '2026-01-12T00:00:00Z'),
+    plVid('sht_kafu_02', '新曲ちょい見せ #shorts', '2026-01-12T06:00:00Z'),
+    plVid('liv_kafu_03', '不可解参 ワンマンライブ映像', '2026-01-12T12:00:00Z'),
+    plVid('ann_kafu_04', '新アルバム発売決定 トレーラー', '2026-01-13T00:00:00Z'),
+    plVid('cov_kafu_05', '理芽とデュエット - Covered by 花譜', '2026-01-13T06:00:00Z'),
+    plVid('old_kafu_06', 'カーソル以前の旧曲', '2026-01-05T00:00:00Z'),
+    plVid('exs_kafu_07', '既存曲（DB登録済み）', '2026-01-14T00:00:00Z'),
+    plVid('mis_kafu_08', '詳細未取得（プレミア処理中）', '2026-01-14T06:00:00Z'),
+  ],
+};
+const INGEST_DETAILS = {
+  items: [
+    ytDetail('sng_kafu_01', '花譜 - 春の歌【オリジナルMV】', '2026-01-12T00:00:00Z', 'PT4M10S'),
+    ytDetail('sht_kafu_02', '新曲ちょい見せ #shorts', '2026-01-12T06:00:00Z', 'PT30S'),
+    ytDetail('liv_kafu_03', '不可解参 ワンマンライブ映像', '2026-01-12T12:00:00Z', 'PT1H2M3S', { live: true }),
+    ytDetail('ann_kafu_04', '新アルバム発売決定 トレーラー', '2026-01-13T00:00:00Z', 'PT2M0S'),
+    ytDetail('cov_kafu_05', '理芽とデュエット - Covered by 花譜', '2026-01-13T06:00:00Z', 'PT3M45S'),
+    ytDetail('exs_kafu_07', '既存曲（DB登録済み）', '2026-01-14T00:00:00Z', 'PT4M0S'),
+    // mis_kafu_08 は意図的に欠落（削除/非公開/プレミア処理中の再現）
+  ],
+};
+const ingestChannelsRoute = (channels) => ({
+  method: 'GET', match: 'ingest_channels?select=*&enabled=eq.true', body: channels,
+});
+const ingestExistingRoute = (rows) => ({
+  method: 'GET', match: 'videos?select=url&limit=10000&offset=0', body: rows,
+});
+
+scenarios.push(
+  { name: 'ingest-youtube/manual-401', fn: 'ingest-youtube', event: post({}), routes: [] },
+  { name: 'ingest-youtube/env-missing', fn: 'ingest-youtube', env: { YOUTUBE_API_KEY: undefined }, event: {}, routes: [] },
+  {
+    name: 'ingest-youtube/scheduled-no-channels', fn: 'ingest-youtube', event: {},
+    routes: [ingestChannelsRoute([])],
+  },
+  {
+    name: 'ingest-youtube/manual-ok-no-channels', fn: 'ingest-youtube',
+    event: post({}, { authorization: `Bearer ${PW}` }),
+    routes: [ingestChannelsRoute([])],
+  },
+  {
+    // 分類全種 + 既存dedup + カーソルクランプ + INSERT + PATCH（外向きbodyもcallsで比較）
+    name: 'ingest-youtube/scheduled-rich', fn: 'ingest-youtube', event: {},
+    routes: [
+      ingestChannelsRoute([CHANNEL]),
+      ingestExistingRoute([{ url: 'https://www.youtube.com/watch?v=exs_kafu_07' }]),
+      { match: (u) => u.includes('playlistItems') && u.includes('UUkafu_dummy'), body: INGEST_PLAYLIST },
+      { match: 'youtube/v3/videos?part=snippet,contentDetails,liveStreamingDetails', body: INGEST_DETAILS },
+      { method: 'POST', match: '/rest/v1/videos', status: 201, body: '' },
+      { method: 'PATCH', match: 'ingest_channels?id=eq.77', status: 204, body: '' },
+    ],
+  },
+  {
+    name: 'ingest-youtube/scheduled-no-new', fn: 'ingest-youtube', event: {},
+    routes: [
+      ingestChannelsRoute([CHANNEL]),
+      ingestExistingRoute([]),
+      { match: (u) => u.includes('playlistItems') && u.includes('UUkafu_dummy'), body: { items: [plVid('old_kafu_06', '旧曲', '2026-01-05T00:00:00Z')] } },
+      { method: 'PATCH', match: 'ingest_channels?id=eq.77', status: 204, body: '' },
+    ],
+  },
+  {
+    name: 'ingest-youtube/overflow-guard', fn: 'ingest-youtube', event: {},
+    routes: [
+      ingestChannelsRoute([CHANNEL]),
+      ingestExistingRoute(bigRows(10000)),
+    ],
+  },
+  {
+    name: 'ingest-youtube/channel-yt-error', fn: 'ingest-youtube', event: {},
+    routes: [
+      ingestChannelsRoute([CHANNEL]),
+      ingestExistingRoute([]),
+      { match: 'playlistItems', body: { error: { message: 'quota exceeded' } } },
+    ],
+  },
+  {
+    name: 'ingest-youtube/resolve-uploads-id', fn: 'ingest-youtube', event: {},
+    routes: [
+      ingestChannelsRoute([{ ...CHANNEL, id: 78, channel_id: 'UCkoko_dummy', member_id: 'koko', uploads_playlist_id: null }]),
+      ingestExistingRoute([]),
+      { match: 'youtube/v3/channels?part=contentDetails', body: { items: [{ contentDetails: { relatedPlaylists: { uploads: 'UUkoko_dummy' } } }] } },
+      { method: 'PATCH', match: 'ingest_channels?id=eq.78', status: 204, body: '' },
+      { match: (u) => u.includes('playlistItems') && u.includes('UUkoko_dummy'), body: { items: [] } },
+    ],
+  },
+  {
+    name: 'ingest-youtube/resolve-uploads-fail', fn: 'ingest-youtube', event: {},
+    routes: [
+      ingestChannelsRoute([{ ...CHANNEL, id: 78, channel_id: 'UCkoko_dummy', member_id: 'koko', uploads_playlist_id: null }]),
+      ingestExistingRoute([]),
+      { match: 'youtube/v3/channels?part=contentDetails', body: { items: [] } },
+    ],
+  },
+  {
+    name: 'ingest-youtube/insert-fail', fn: 'ingest-youtube', event: {},
+    routes: [
+      ingestChannelsRoute([CHANNEL]),
+      ingestExistingRoute([]),
+      { match: (u) => u.includes('playlistItems') && u.includes('UUkafu_dummy'), body: { items: [plVid('sng_kafu_01', '花譜 - 春の歌【オリジナルMV】', '2026-01-12T00:00:00Z')] } },
+      { match: 'youtube/v3/videos?part=snippet,contentDetails,liveStreamingDetails', body: { items: [ytDetail('sng_kafu_01', '花譜 - 春の歌【オリジナルMV】', '2026-01-12T00:00:00Z', 'PT4M10S')] } },
+      { method: 'POST', match: '/rest/v1/videos', status: 500, body: 'db down '.repeat(40) },
+    ],
+  },
+  {
+    // sbFetch errSlice=300 の境界確認（350文字 → 300に切り詰め）
+    name: 'ingest-youtube/channels-sb-error-slice300', fn: 'ingest-youtube', event: {},
+    routes: [{ method: 'GET', match: 'ingest_channels', status: 500, body: 'E'.repeat(350) }],
+  },
+);
+
+// ═══════════════════════════════════════════════════════════════
+// observer-link-exchange（全パス）
+// ═══════════════════════════════════════════════════════════════
+const EXH = { 'x-nf-client-connection-ip': CLIENT_IP };
+const CLIENT_HASH = sha256(CLIENT_IP);
+const exRate = (rows) => ({
+  method: 'GET', match: (u) => u.includes('song_bottles?select=id&client_hash=eq.'), body: rows,
+});
+const exVideoById = (id, rows, { retry42703 = false } = {}) => retry42703
+  ? [
+    { method: 'GET', match: (u) => u.includes(`id=eq.${id}`) && u.includes('rest/v1/videos') && u.includes('status=eq.published'), status: 400, body: 'code 42703: column videos.status does not exist' },
+    { method: 'GET', match: (u) => u.includes(`id=eq.${id}`) && u.includes('rest/v1/videos') && !u.includes('status=eq.published'), body: rows },
+  ]
+  : [{ method: 'GET', match: (u) => u.includes(`id=eq.${id}`) && u.includes('rest/v1/videos') && u.includes('status=eq.published'), body: rows }];
+const exInsert = (rows) => ({
+  method: 'POST', match: 'rest/v1/song_bottles', status: 201, body: rows,
+});
+const exCandidates = (rows) => ({
+  method: 'GET', match: (u) => u.includes('song_bottles?select=*&status=eq.waiting'), body: rows,
+});
+const exFallbackList = (rows) => ({
+  method: 'GET', match: (u) => u.includes('rest/v1/videos') && u.includes('limit=50') && u.includes('status=eq.published'), body: rows,
+});
+const MY_BOTTLE = { id: B_MINE, video_id: 5, mood_tags: ['Night'], message: 'よい夜を', client_hash: CLIENT_HASH, status: 'waiting', created_at: '2026-01-15T12:00:00.000Z' };
+const OTHER_BOTTLE = { id: B_OTHER, video_id: 9, mood_tags: ['Rain'], message: '雨の日に', client_hash: 'otherhash', status: 'waiting', created_at: '2026-01-15T11:00:00.000Z' };
+const THIRD_BOTTLE = { id: B_THIRD, video_id: 12, mood_tags: [], message: null, client_hash: 'thirdhash', status: 'waiting', created_at: '2026-01-15T10:00:00.000Z' };
+
+scenarios.push(
+  { name: 'exchange/options', fn: 'observer-link-exchange', event: { httpMethod: 'OPTIONS', headers: EXH }, routes: [] },
+  { name: 'exchange/405-get', fn: 'observer-link-exchange', event: { httpMethod: 'GET', headers: EXH }, routes: [] },
+  { name: 'exchange/invalid-json', fn: 'observer-link-exchange', event: post('{{{', EXH), routes: [] },
+  { name: 'exchange/invalid-video-id', fn: 'observer-link-exchange', event: post({ video_id: 'abc' }, EXH), routes: [] },
+  {
+    name: 'exchange/rate-limit', fn: 'observer-link-exchange',
+    event: post({ video_id: 5 }, EXH),
+    routes: [exRate(Array.from({ length: 10 }, (_, i) => ({ id: i + 1 })))],
+  },
+  {
+    name: 'exchange/video-not-published', fn: 'observer-link-exchange',
+    event: post({ video_id: 5 }, EXH),
+    routes: [exRate([]), ...exVideoById(5, [])],
+  },
+  {
+    name: 'exchange/matched', fn: 'observer-link-exchange',
+    event: post({ video_id: 5, mood_tags: ['Night', 'Chill', 'Rain'], message: 'この曲をどうぞ、20文字超えたら切り詰め' }, EXH),
+    routes: [
+      exRate([{ id: 1 }, { id: 2 }]),
+      ...exVideoById(5, [VIDEO5]),
+      exInsert([MY_BOTTLE]),
+      exCandidates([OTHER_BOTTLE, THIRD_BOTTLE]),
+      { method: 'PATCH', match: (u) => u.includes(`id=eq.${B_OTHER}`) && u.includes('status=eq.waiting'), body: [{ ...OTHER_BOTTLE, status: 'matched', matched_with: B_MINE }] },
+      { method: 'PATCH', match: (u) => u.includes(`id=eq.${B_MINE}`), body: [{ ...MY_BOTTLE, status: 'matched', matched_with: B_OTHER }] },
+      ...exVideoById(9, [VIDEO9]),
+    ],
+  },
+  {
+    name: 'exchange/race-lost-to-fallback', fn: 'observer-link-exchange',
+    event: post({ video_id: 5 }, EXH),
+    routes: [
+      exRate([]),
+      ...exVideoById(5, [VIDEO5]),
+      exInsert([MY_BOTTLE]),
+      exCandidates([OTHER_BOTTLE]),
+      { method: 'PATCH', match: (u) => u.includes(`id=eq.${B_OTHER}`) && u.includes('status=eq.waiting'), body: [] },
+      exFallbackList([VIDEO5, VIDEO9, VIDEO12]),
+      { method: 'PATCH', match: (u) => u.includes(`id=eq.${B_MINE}`), body: [{ ...MY_BOTTLE, status: 'fallback_matched' }] },
+    ],
+  },
+  {
+    name: 'exchange/no-candidates-fallback', fn: 'observer-link-exchange',
+    event: post({ video_id: 5, mood_tags: 'not-an-array', message: 42 }, EXH),
+    routes: [
+      exRate([]),
+      ...exVideoById(5, [VIDEO5]),
+      exInsert([MY_BOTTLE]),
+      exCandidates([]),
+      exFallbackList([VIDEO5, VIDEO9, VIDEO12]),
+      { method: 'PATCH', match: (u) => u.includes(`id=eq.${B_MINE}`), body: [{ ...MY_BOTTLE, status: 'fallback_matched' }] },
+    ],
+  },
+  {
+    name: 'exchange/fallback-empty-pool', fn: 'observer-link-exchange',
+    event: post({ video_id: 5 }, EXH),
+    routes: [
+      exRate([]),
+      ...exVideoById(5, [VIDEO5]),
+      exInsert([MY_BOTTLE]),
+      exCandidates([]),
+      exFallbackList([VIDEO5]), // sent自身のみ → pool空 → received:null（PATCHなし）
+    ],
+  },
+  {
+    name: 'exchange/42703-retry', fn: 'observer-link-exchange',
+    event: post({ video_id: 5 }, EXH),
+    routes: [
+      exRate([]),
+      ...exVideoById(5, [VIDEO5], { retry42703: true }),
+      exInsert([MY_BOTTLE]),
+      exCandidates([]),
+      { method: 'GET', match: (u) => u.includes('rest/v1/videos') && u.includes('limit=50') && u.includes('status=eq.published'), status: 400, body: 'code 42703: column videos.status does not exist' },
+      { method: 'GET', match: (u) => u.includes('rest/v1/videos') && u.includes('limit=50') && !u.includes('status=eq.published'), body: [VIDEO5, VIDEO9] },
+      { method: 'PATCH', match: (u) => u.includes(`id=eq.${B_MINE}`), body: [{ ...MY_BOTTLE, status: 'fallback_matched' }] },
+    ],
+  },
+  {
+    name: 'exchange/insert-empty', fn: 'observer-link-exchange',
+    event: post({ video_id: 5 }, EXH),
+    routes: [exRate([]), ...exVideoById(5, [VIDEO5]), exInsert([])],
+  },
+  {
+    name: 'exchange/admin-bypass', fn: 'observer-link-exchange',
+    event: post({ video_id: 5 }, { ...EXH, 'x-admin-key': PW }),
+    routes: [
+      // rate limit fetch はスキップされる（callsに出ないことを比較で保証）
+      ...exVideoById(5, [VIDEO5]),
+      exInsert([MY_BOTTLE]),
+      exCandidates([]),
+      exFallbackList([VIDEO5, VIDEO9]),
+      { method: 'PATCH', match: (u) => u.includes(`id=eq.${B_MINE}`), body: [{ ...MY_BOTTLE, status: 'fallback_matched' }] },
+    ],
+  },
+  {
+    name: 'exchange/match-patch-http-fail', fn: 'observer-link-exchange',
+    event: post({ video_id: 5 }, EXH),
+    routes: [
+      exRate([]),
+      ...exVideoById(5, [VIDEO5]),
+      exInsert([MY_BOTTLE]),
+      exCandidates([OTHER_BOTTLE]),
+      { method: 'PATCH', match: (u) => u.includes(`id=eq.${B_OTHER}`) && u.includes('status=eq.waiting'), status: 500, body: 'patch failed' },
+    ],
+  },
+  {
+    // sbFetch errSlice=200 経路（250文字エラー → throw → 500 INTERNAL_ERROR）
+    name: 'exchange/sb-error', fn: 'observer-link-exchange',
+    event: post({ video_id: 5 }, EXH),
+    routes: [{ method: 'GET', match: (u) => u.includes('song_bottles?select=id&client_hash=eq.'), status: 500, body: 'F'.repeat(250) }],
+  },
+);
+
+// ═══════════════════════════════════════════════════════════════
+// observer-link-result（4種HTML全文一致）
+// ═══════════════════════════════════════════════════════════════
+const rsBottle = (rows) => ({
+  method: 'GET', match: (u) => u.includes(`song_bottles?select=*&id=eq.${B_MINE}`), body: rows,
+});
+const rsMatchedBottle = (rows) => ({
+  method: 'GET', match: (u) => u.includes(`song_bottles?select=*&id=eq.${B_OTHER}`), body: rows,
+});
+const rsVideoById = (id, rows) => ({
+  method: 'GET', match: (u) => u.includes(`id=eq.${id}`) && u.includes('rest/v1/videos') && u.includes('status=eq.published'), body: rows,
+});
+
+scenarios.push(
+  { name: 'result/405-post', fn: 'observer-link-result', event: post({}), routes: [] },
+  { name: 'result/no-id-expired', fn: 'observer-link-result', event: get(null), routes: [] },
+  { name: 'result/bad-uuid-expired', fn: 'observer-link-result', event: get({ id: 'not-a-uuid' }), routes: [] },
+  {
+    name: 'result/not-found-expired', fn: 'observer-link-result',
+    event: get({ id: B_MINE }),
+    routes: [rsBottle([])],
+  },
+  {
+    name: 'result/waiting-page', fn: 'observer-link-result',
+    event: get({ id: B_MINE }),
+    routes: [
+      rsBottle([{ id: B_MINE, video_id: 5, status: 'waiting', matched_with: null, message: '待機中のメッセージ', created_at: '2026-01-15T10:00:00.000Z' }]),
+      rsVideoById(5, [VIDEO5]),
+    ],
+  },
+  {
+    name: 'result/matched-page', fn: 'observer-link-result',
+    event: get({ id: B_MINE }),
+    routes: [
+      rsBottle([{ id: B_MINE, video_id: 5, status: 'matched', matched_with: B_OTHER, message: '私のメッセージ<b>', created_at: '2026-01-15T10:00:00.000Z' }]),
+      rsVideoById(5, [VIDEO5]),
+      rsMatchedBottle([{ id: B_OTHER, video_id: 9, status: 'matched', matched_with: B_MINE, message: '相手の"メッセージ"', created_at: '2026-01-14T12:00:00.000Z' }]),
+      rsVideoById(9, [VIDEO9]),
+    ],
+  },
+  {
+    name: 'result/fallback-page', fn: 'observer-link-result',
+    event: get({ id: B_MINE }),
+    routes: [
+      rsBottle([{ id: B_MINE, video_id: 5, status: 'fallback_matched', matched_with: null, fallback_video_id: 12, message: 'fbメッセージ', created_at: '2026-01-15T10:00:00.000Z' }]),
+      rsVideoById(5, [VIDEO5]),
+      rsVideoById(12, [VIDEO12]),
+    ],
+  },
+  {
+    name: 'result/matched-no-received-expired', fn: 'observer-link-result',
+    event: get({ id: B_MINE }),
+    routes: [
+      rsBottle([{ id: B_MINE, video_id: 5, status: 'matched', matched_with: null, message: null, created_at: '2026-01-15T10:00:00.000Z' }]),
+      rsVideoById(5, [VIDEO5]),
+    ],
+  },
+  {
+    name: 'result/42703-retry-waiting', fn: 'observer-link-result',
+    event: get({ id: B_MINE }),
+    routes: [
+      rsBottle([{ id: B_MINE, video_id: 5, status: 'waiting', matched_with: null, message: null, created_at: '2026-01-15T10:00:00.000Z' }]),
+      { method: 'GET', match: (u) => u.includes('id=eq.5') && u.includes('rest/v1/videos') && u.includes('status=eq.published'), status: 400, body: 'code 42703: column videos.status does not exist' },
+      { method: 'GET', match: (u) => u.includes('id=eq.5') && u.includes('rest/v1/videos') && !u.includes('status=eq.published'), body: [VIDEO5] },
+    ],
+  },
+  {
+    name: 'result/error-expired', fn: 'observer-link-result',
+    event: get({ id: B_MINE }),
+    routes: [{ method: 'GET', match: 'song_bottles', networkError: 'network down dummy' }],
+  },
+);
+
+// ═══════════════════════════════════════════════════════════════
+// albums-get / videos-get
+// ═══════════════════════════════════════════════════════════════
+scenarios.push(
+  {
+    name: 'albums-get/success', fn: 'albums-get', event: get(),
+    routes: [{ method: 'GET', match: '/rest/v1/albums', body: [{ id: 1, member: 'kafu', name: '狂想', purchase_url: null, is_sold_out: false }] }],
+  },
+  {
+    name: 'albums-get/error', fn: 'albums-get', event: get(),
+    routes: [{ method: 'GET', match: '/rest/v1/albums', networkError: 'network down dummy' }],
+  },
+  {
+    name: 'videos-get/single-page', fn: 'videos-get', event: get(),
+    routes: [{ method: 'GET', match: (u) => u.endsWith('offset=0'), body: [VIDEO5, VIDEO9, VIDEO12] }],
+  },
+  {
+    name: 'videos-get/multi-page', fn: 'videos-get', event: get(),
+    routes: [
+      { method: 'GET', match: (u) => u.endsWith('offset=1000'), body: () => pageRows(500, 1000) },
+      { method: 'GET', match: (u) => u.endsWith('offset=0'), body: () => pageRows(1000, 0) },
+    ],
+  },
+  {
+    name: 'videos-get/empty', fn: 'videos-get', event: get(),
+    routes: [{ method: 'GET', match: (u) => u.endsWith('offset=0'), body: [] }],
+  },
+  {
+    name: 'videos-get/42703-retry', fn: 'videos-get', event: get(),
+    routes: [
+      { method: 'GET', match: (u) => u.includes('status=eq.published'), status: 400, body: 'code 42703: column videos.status does not exist' },
+      { method: 'GET', match: (u) => !u.includes('status=eq.published'), body: [VIDEO5, VIDEO9] },
+    ],
+  },
+  {
+    name: 'videos-get/sb-error-no-store', fn: 'videos-get', event: get(),
+    routes: [{ method: 'GET', match: 'rest/v1/videos', status: 500, body: 'db is on fire' }],
+  },
+  {
+    name: 'videos-get/non-array', fn: 'videos-get', event: get(),
+    routes: [{ method: 'GET', match: 'rest/v1/videos', body: { message: 'unexpected' } }],
+  },
+);
+
+// ═══════════════════════════════════════════════════════════════
+// youtube（B3では完全無変更 — 回帰検知のためスナップショットには含める）
+// ═══════════════════════════════════════════════════════════════
+scenarios.push(
+  { name: 'youtube/invalid-id', fn: 'youtube', event: get({ id: 'short' }), routes: [] },
+  { name: 'youtube/env-missing', fn: 'youtube', env: { YOUTUBE_API_KEY: undefined }, event: get({ id: 'AAAAAAAAAAA' }), routes: [] },
+  {
+    name: 'youtube/yt-error', fn: 'youtube', event: get({ id: 'AAAAAAAAAAA' }),
+    routes: [{ match: 'youtube/v3/videos', body: { error: { message: 'API key invalid' } } }],
+  },
+  {
+    name: 'youtube/not-found', fn: 'youtube', event: get({ id: 'AAAAAAAAAAA' }),
+    routes: [{ match: 'youtube/v3/videos', body: { items: [] } }],
+  },
+  {
+    name: 'youtube/success', fn: 'youtube', event: get({ id: 'AAAAAAAAAAA' }),
+    routes: [{
+      match: 'youtube/v3/videos',
+      body: { items: [{ snippet: { title: '糸', publishedAt: '2023-01-01T09:00:00Z', thumbnails: { medium: { url: 'https://i.ytimg.com/med.jpg' }, default: { url: 'https://i.ytimg.com/def.jpg' } } } }] },
+    }],
+  },
+  {
+    name: 'youtube/network-error', fn: 'youtube', event: get({ id: 'AAAAAAAAAAA' }),
+    routes: [{ match: 'youtube/v3/videos', networkError: 'network down dummy' }],
+  },
+);


### PR DESCRIPTION
## 目的

改修企画書 柱B Phase 3（最終フェーズ）。netlify/functions/ 16ファイルの内部実装重複（Supabase初期化・sbFetch・ytId・playlistItemsページング・全件fetchガード・SHA-256・定型レスポンス）を `_shared/` 4ファイルに一元化する。**エンドポイント・メソッド・ステータス・レスポンスbody・ヘッダは1バイトも変えない。** 計画はYuki承認済み。

## 変更したもの

- `netlify/functions/_shared/` 新設4ファイル（supabase / client-hash / responses / yt、全CommonJS。Netlifyの Function 認識対象外）
- 15 Functions を6コミットでリスク昇順に書き換え（admin CRUD → adminトークン系 → ingest → 公開read系 → OL系）。**youtube.js は完全無変更**
- `tests/fn-snapshot/` 新設（回帰資産として残置、Yuki承認済み）: 全handlerをモックevent+fetchスタブで直接呼び、**戻り値全体と外向きリクエスト（DBへ送るURL・メソッド・ヘッダ・body）を逐語記録**して main と比較するハーネス。145シナリオ / 16 Function
- exchange（憲法6）はdiffを「先頭のrequire+重複定義の置換+キー選択1行」の3 hunkに物理制限。handler本体・フォールバックPATCH・42703リトライは1文字も変更なし。result（憲法7）はrequire+キー選択のみ

## 変更していないもの（保証事項）

- **スナップショット同値保証**: main vs 本ブランチで145シナリオの入出力+外向きリクエストのdiffが**空**（implementerとreviewerが独立実行で双方確認。bodyはバイト比較、fixture調整ゼロ）
- 意図的に統一していないもの（外部に見える差異のため）: エラーJSON 3系統 / CORS 3パターン / 認証4方式・401文言（'Unauthorized' vs 日本語）/ 42703リトライ3変種 / playlist-import二重実装 / サムネ優先順位差
- `status=eq.published` は前後とも16箇所・同一ファイルで不変（憲法2）/ 憲法5チェック完了: limit追加が必要な箇所ゼロ（#119で完了済み）/ netlify.toml・public/・supabase/ 不触（`/result/` force=true 不変）

## レビュー往復履歴（reviewerの指摘と対応）

- reviewer判定: **APPROVE**（CRITICAL/HIGH/MEDIUMゼロ）
- 検証内容: スナップショットdiff空の独立再実行（145件）/ ハーネス欺瞞検査（bodyバイト比較・過剰正規化なし・外向きcallsもdiff対象であることを精読確認）/ ⛔項目非侵害のdiff全確認 / exchangeのhunk物理位置 / _shared実装と計画シグネチャの突合 / require解決 / git履歴健全性
- LOW 3件（非ブロッカー、将来向け）: fetchスタブにレスポンスheadersなし / requireキャッシュとenv-missingシナリオの順序依存性 / albums-get・videos-getのみgetSupabaseUrl()未適用の見た目不揃い
- 計画からの逸脱3件（いずれも妥当と判定）: fetchAllVideoRowsのthrowOnHttpErrorオプション（ingestと他2ファイルの現行エラー挙動差の保存に必要）/ getSupabaseUrl()のG4/G5非適用（最保守）/ resultのrequire行追加

## 動作確認方法（Yuki向け手順）

**私（オーケストレーター）がデプロイプレビューで実施済み/実施予定**: 認証不要のcurl検証（videos-get/albums-get の本番との正規化diff、Cache-Control、405/不正JSON/認証失敗の文言バイト一致、OPTIONSプリフライト、expiredページ、Functions一覧16個）→ 結果はPRコメントに追記します。

**Yukiにお願いする認証つき検証**（ADMIN_PASSWORDが必要なため。プレビューURLを `$P`、パスワードを `$PW` として）:

```bash
# 1. admin-auth → token → admin-query（本番と同クエリでdiff）
TOKEN=$(curl -s -X POST $P/.netlify/functions/admin-auth -d "{\"password\":\"$PW\"}" | jq -r .token)
curl -s -X POST $P/.netlify/functions/admin-query -H "Authorization: Bearer $TOKEN" \
  -d '{"action":"query","table":"videos","select":"id","limit":"5","order":"id.asc"}' | jq -S .

# 2. exchange→result 一連（x-admin-keyでレート枠不消費）
R=$(curl -s -X POST $P/.netlify/functions/observer-link-exchange \
  -H "x-admin-key: $PW" -H "Content-Type: application/json" \
  -d '{"video_id": <published曲のid>, "mood_tags":["Night"], "message":"b3-verify"}')
echo $R | jq '{success, is_fallback}'
# → $P/result/?id=<exchange_id> と本番の /result/?id=同ID のHTMLが同一表示であること

# 3. テストbottleの削除（承認済みの後始末）
# admin画面のBOTTLES、または admin-query の delete action で message='b3-verify' の行を削除

# 4. ingest手動起動（承認済み）
curl -s -X POST $P/.netlify/functions/ingest-youtube -H "Authorization: Bearer $PW" | jq .
# → {ok:true, processed:5} 形式。新着があればINCOMINGキューに着弾
```

5. マージ後、本番でadmin画面のSONGS/BOTTLES表示・プレイリストインポート・公開サイトの通常動作を一巡確認

## 判断保留リスト

- reviewer LOW 3件（上記）は将来のFunctions変更時の注意点としてtests/fn-snapshot/のコメント整備で対応可（別途）
- exchange L211のフォールバック候補order未指定（抽選の偏り）は現状維持（監査記録済み、挙動変更になるため）
- スナップショットは「前後比較」専用で絶対的正しさは保証しない（実挙動はデプロイプレビューcurlで担保する二層設計）

🤖 Generated with [Claude Code](https://claude.com/claude-code)