### PR TITLE
fix(ingest): 定期実行をGitHub Actions cronに移行（Netlifyスケジュール未登録問題の回避）

### DIFF
--- a/.github/workflows/ingest-youtube.yml
+++ b/.github/workflows/ingest-youtube.yml
@@ -1,0 +1,37 @@
+# ingest-youtube 定期起動（GitHub Actions cron）
+#
+# 経緯: netlify.toml の [functions."ingest-youtube"] schedule がNetlify側に
+# 登録されず一度も実行されていなかった問題（2026-07-10診断）の回避策。
+# Netlifyのスケジュール登録をやめ、GitHub ActionsからHTTPで手動起動する。
+#
+# 注意:
+# - schedule はデフォルトブランチ（main）上のworkflowのみ実行される（マージ後に有効化）。
+# - リポジトリが60日間非活動だとGitHubがcronを自動停止する（手動で再有効化が必要）。
+# - Secret `ADMIN_PASSWORD` をリポジトリのActions secretsに登録すること（Yuki）。
+
+name: ingest-youtube
+
+on:
+  schedule:
+    - cron: '0 */6 * * *' # UTC、6時間ごと（従来のnetlify.toml設定と同じ間隔）
+  workflow_dispatch: # 手動実行用
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Invoke ingest-youtube function
+        run: |
+          set -euo pipefail
+          response=$(curl -sf --max-time 120 -X POST \
+            -H "Authorization: Bearer ${{ secrets.ADMIN_PASSWORD }}" \
+            https://vwp-archive.netlify.app/.netlify/functions/ingest-youtube)
+          echo "Response: ${response}"
+          ok=$(echo "${response}" | jq -r '.ok')
+          processed=$(echo "${response}" | jq -r '.processed')
+          echo "ok=${ok} processed=${processed}"
+          if [ "${ok}" != "true" ]; then
+            echo "ingest-youtube returned ok != true" >&2
+            exit 1
+          fi

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,9 +2,6 @@
   publish = "public"
   functions = "netlify/functions"
 
-[functions."ingest-youtube"]
-  schedule = "0 */6 * * *"
-
 [[redirects]]
   from = "/result/"
   to = "/.netlify/functions/observer-link-result"


### PR DESCRIPTION
## 目的

自動取り込み（ingest-youtube）が**一度も定期実行されていなかった問題**の修正。診断結果: 関数・APIキー・DBはすべて正常だが、netlify.tomlの `schedule` がNetlify側に登録されておらず（書式は公式ドキュメントどおりにもかかわらず）、4回以上の実行枠を無反応で通過していた。Yuki承認の案C（GitHub Actions cron方式）。

## 変更したもの

- `.github/workflows/ingest-youtube.yml` 新規（+37行）: 6時間ごと（UTC 0/6/12/18時 = JST 9/15/21/3時、従来と同間隔）に本番の ingest-youtube をBearer認証でHTTP起動。`workflow_dispatch` で手動実行も可能。レスポンスの `ok != true` でジョブ失敗（GitHub通知が機能）
- `netlify.toml`: 機能していなかった `[functions."ingest-youtube"]` scheduleブロックを削除（-3行。将来Netlify側が直った場合の二重実行を防止）

## 変更していないもの（保証事項）

- netlify/functions/・public/ は未接触。netlify.tomlの `/result/` force=trueリダイレクト・headers等は無傷（diffはscheduleブロック削除の1 hunkのみ）
- Secretはログに出力されない（レスポンスJSONのみecho）

## マージ前に必要な作業（Yuki）

**GitHub Secretの登録**: Settings → Secrets and variables → Actions → New repository secret で Name `ADMIN_PASSWORD` / Value 管理者パスワード。未登録のままマージするとジョブが401で失敗します（失敗通知は来るので気づけます）。

## 動作確認方法（Yuki向け手順）

1. Secret登録 → 本PRマージ
2. Actionsタブ → ingest-youtube → **Run workflow** で手動実行
3. ジョブログに `ok=true processed=5` が出ること
4. /admin のSONGSタブに INCOMING TRANSMISSION バッジが出て、5チャンネルの直近動画がpendingで並ぶこと（初回はやや多めに入る想定。公開はPUBLISH操作のみ）
5. 以降は6時間ごとにActionsに実行履歴が残る

## 判断保留リスト

- GitHubの仕様: cronはmainマージ後に有効化 / リポジトリ60日非活動でcron自動停止（workflowコメントに記載済み）
- Netlify側のスケジュール登録がなぜ効かなかったかの根本原因は未特定（Netlifyサポート案件）。本方式は実行履歴の可視性が高く、恒久運用として問題ない判断

🤖 Generated with [Claude Code](https://claude.com/claude-code)