### PR TITLE
feat(ingest): 自動取り込みをstatus='published'着地に変更 + 憲法10改訂（Yuki決定 2026-07-14）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Vanilla HTML/CSS/JS + Netlify Functions + Supabase。収益なし、本番稼働
 7. **netlify.toml** の `/result/` リダイレクトは `force=true` 必須。
 8. **windowに露出している関数・変数を消さない。** Chrome拡張（VWP New Tab）が `Object.defineProperty` でwindow変数を監視する。ES Modules化しても外部依存のあるものは `window.xxx = xxx` で露出を維持。
 9. **KAMITSUBAKIガイドライン**: 非商業・UNOFFICIAL明示・公式素材の使用禁止。音楽再生はYouTube別タブ遷移のみ（IFrame埋め込みは採用しない）。
-10. **ingest-youtube の自動取り込みは `status='published'` で着地する**（2026-07-14 Yuki決定により改訂）。公開後の品質管理は事後運用: admin で REJECT / 編集可。`rejected` への遷移経路は維持する。**前提条件**: dedup 全件fetchのページングループ（憲法5）が正しく機能していること。dedup が壊れた状態での自動publishは重複が即サイトに出るため、憲法5違反は本条の停止条件になる。手動経路（playlist-import / videos-add / admin）は従来どおり `status='pending'` で人間が公開判断する（自動publishの対象は ingest-youtube のみ）。
+10. **videos の status default は `'published'`**（2026-07-14 Yuki決定により改訂）。ingest-youtube は `status='published'` を明示してINSERT。手動経路（playlist-import / videos-add）は status 未指定 = DB default の `published` で即着地する（操作者自身が公開判断者のため）。`pending` は admin での明示的な保留・審査用ステータスとして残し、`rejected` への遷移経路も維持する。**前提条件**: dedup 全件fetchのページングループ（憲法5）が正しく機能していること。dedup が壊れた状態での自動publishは重複が即サイトに出るため、憲法5違反は本条の停止条件になる。
 
 ## 設計思想
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Vanilla HTML/CSS/JS + Netlify Functions + Supabase。収益なし、本番稼働
 7. **netlify.toml** の `/result/` リダイレクトは `force=true` 必須。
 8. **windowに露出している関数・変数を消さない。** Chrome拡張（VWP New Tab）が `Object.defineProperty` でwindow変数を監視する。ES Modules化しても外部依存のあるものは `window.xxx = xxx` で露出を維持。
 9. **KAMITSUBAKIガイドライン**: 非商業・UNOFFICIAL明示・公式素材の使用禁止。音楽再生はYouTube別タブ遷移のみ（IFrame埋め込みは採用しない）。
-10. **自動publishは永久にしない。** 自動取り込みは常に `status='pending'` 止まり。公開判断は人間。
+10. **ingest-youtube の自動取り込みは `status='published'` で着地する**（2026-07-14 Yuki決定により改訂）。公開後の品質管理は事後運用: admin で REJECT / 編集可。`rejected` への遷移経路は維持する。**前提条件**: dedup 全件fetchのページングループ（憲法5）が正しく機能していること。dedup が壊れた状態での自動publishは重複が即サイトに出るため、憲法5違反は本条の停止条件になる。手動経路（playlist-import / videos-add / admin）は従来どおり `status='pending'` で人間が公開判断する（自動publishの対象は ingest-youtube のみ）。
 
 ## 設計思想
 

--- a/netlify/functions/ingest-youtube.js
+++ b/netlify/functions/ingest-youtube.js
@@ -2,7 +2,8 @@
 // ingest-youtube.js — YouTube自動取り込みFunction
 // スケジュール: 6時間ごと (netlify.toml で設定)
 // 手動起動: Authorization: Bearer <ADMIN_PASSWORD> が必要
-// 自動publish禁止 — 取り込みは常に status='pending' 止まり
+// 取り込みは status='published' 着地（2026-07-14 Yuki決定・憲法10改訂済み）
+// 前提: dedup全件fetchのページングループ（憲法5）が正しく動作していること
 // ═══════════════════════════════════════════════════════════════
 
 const { getSupabaseUrl, secretKey, sbHeaders: buildSbHeaders, sbFetch, fetchAllVideoRows } = require('./_shared/supabase');
@@ -303,7 +304,7 @@ exports.handler = async (event) => {
             note: '',
             spotify_url: null,
             album_id: null,
-            status: 'pending',        // 自動publishは絶対禁止
+            status: 'published',      // 憲法10改訂: 自動取り込みはpublished着地（2026-07-14 Yuki決定）
             content_type: contentType,
             source: 'youtube_auto',
             ingested_at: new Date().toISOString()
@@ -312,7 +313,7 @@ exports.handler = async (event) => {
           if (publishedAt) resolvedPubs.push(publishedAt);
         }
 
-        // (g) INSERT（status='pending', source='youtube_auto', ingested_at=now()）
+        // (g) INSERT（status='published', source='youtube_auto', ingested_at=now()）
         let inserted = 0;
         if (toInsert.length > 0) {
           const insRes = await fetch(


### PR DESCRIPTION
## 目的

Yuki の明示決定（2026-07-14）により憲法10「自動publishは永久にしない」を廃止し、YouTube自動取り込みを全自動公開に変更する。品質管理は事後運用（admin で REJECT / 編集）。

**依存: PR #125（dedupページング修正）を先にマージすること。** 本PRのbaseは `fix/postgrest-maxrows-pagination`。dedup が1,000件で切り詰められた状態で自動publishすると重複が即サイトに出るため、憲法5準拠が本改訂の前提条件（新憲法10に停止条件として明記）。

## 変更したもの

- `CLAUDE.md` 憲法10改訂: videos の status default は `'published'`。ingest-youtube は `status='published'` 明示INSERT。手動経路（playlist-import / videos-add）は DB default で即 published 着地（操作者自身が公開判断者のため）。`pending` は admin の保留・審査用として残し、`rejected` 遷移経路も維持。憲法5違反は本条の停止条件
- `netlify/functions/ingest-youtube.js`: INSERT の `status: 'pending'` → `'published'`（実質1行）+ ヘッダコメント更新

## 変更していないもの（保証事項）

- dedup（fetchAllVideoRows・status無フィルタ全件）・cursor・分類・member判定・エラーハンドリング不変
- **ゾンビ復活なし（reviewer実コード追跡済み）**: admin REJECT は PATCH（行は残る）→ dedup が videoId を捕捉 → REJECT済み動画の再取り込み・再公開は起きない。cursor が一次ガード、dedup が二次ガードの二重化
- 公開系クエリの `status=eq.published` フィルタ（憲法2）不変。videos-get / observer-link 系すべて確認済み
- 手動経路（playlist-import / videos-add）のコード不変
- localStorage キー・window露出・CSSスコープ・song_bottles・netlify.toml 不変
- fn-snapshot 156シナリオ: 差分は ingest INSERT body の status のみ（2シナリオ）

## レビュー往復履歴（reviewerの指摘と対応）

2往復（上限内）:

1. **誤ファイル改訂**（オーケストレータ検出）: untracked の `vwp_opus_orchestrator/CLAUDE.md` を誤って改訂・追跡 → コミット作り直しでルート CLAUDE.md に適用、untracked 混入除去
2. **W1**: 新憲法10の「手動経路は pending」が実態（migration の `DEFAULT 'published'`、playlist-import/videos-add は status 未指定）と矛盾 → 文面を実態に整合（84da403、コード変更なし）
3. **W2（情報提供・対応なし）**: live/shorts/announcement も無審査で公開サイトに載る（公開フロントに content_type フィルタなし）。Yuki が全自動選択時に許容済み。期間限定アーカイブ（例: 報奏部）は期限切れ後も残るため事後 REJECT 運用
4. 最終判定 APPROVE 相当（CRITICAL/MAJOR なし）

## 動作確認方法（Yuki向け手順）

マージ後、次の cron（6時間ごと）実行を待って:

1. Supabase で videos を ingested_at 降順ソート → 最新行の status が `published`、source が `youtube_auto`
2. 公開サイトをシークレットウィンドウで開き、新着が承認なしで表示されること
3. 重複確認: `SELECT url, COUNT(*) FROM videos GROUP BY url HAVING COUNT(*) > 1` が0件（dedupページングの間接確認）
4. admin LIBRARY で published→pending/rejected へ手動変更できること（保留経路の維持確認）

## 判断保留リスト

- **W2 の緩和策**（任意・後続）: announcement / live だけ pending に落とす条件付きゲート。現状は全公開+事後REJECT運用
- **既存 pending 242件は本PRと別に一括publish済み**（published=1,560 / pending=0、2026-07-14 手動SQL、Yuki承認）
- 期間限定アーカイブ（報奏部 vol.62 等）が期限切れ後もサイトに残る問題は事後 REJECT で対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)