### PR TITLE
feat(ingest): 自動取り込みをstatus='published'着地に変更 + 憲法10改訂（Yuki決定 2026-07-14）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Vanilla HTML/CSS/JS + Netlify Functions + Supabase。収益なし、本番稼働
 7. **netlify.toml** の `/result/` リダイレクトは `force=true` 必須。
 8. **windowに露出している関数・変数を消さない。** Chrome拡張（VWP New Tab）が `Object.defineProperty` でwindow変数を監視する。ES Modules化しても外部依存のあるものは `window.xxx = xxx` で露出を維持。
 9. **KAMITSUBAKIガイドライン**: 非商業・UNOFFICIAL明示・公式素材の使用禁止。音楽再生はYouTube別タブ遷移のみ（IFrame埋め込みは採用しない）。
-10. **ingest-youtube の自動取り込みは `status='published'` で着地する**（2026-07-14 Yuki決定により改訂）。公開後の品質管理は事後運用: admin で REJECT / 編集可。`rejected` への遷移経路は維持する。**前提条件**: dedup 全件fetchのページングループ（憲法5）が正しく機能していること。dedup が壊れた状態での自動publishは重複が即サイトに出るため、憲法5違反は本条の停止条件になる。手動経路（playlist-import / videos-add / admin）は従来どおり `status='pending'` で人間が公開判断する（自動publishの対象は ingest-youtube のみ）。
+10. **videos の status default は `'published'`**（2026-07-14 Yuki決定により改訂）。ingest-youtube は `status='published'` を明示してINSERT。手動経路（playlist-import / videos-add）は status 未指定 = DB default の `published` で即着地する（操作者自身が公開判断者のため）。`pending` は admin での明示的な保留・審査用ステータスとして残し、`rejected` への遷移経路も維持する。**前提条件**: dedup 全件fetchのページングループ（憲法5）が正しく機能していること。dedup が壊れた状態での自動publishは重複が即サイトに出るため、憲法5違反は本条の停止条件になる。
 
 ## 設計思想
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Vanilla HTML/CSS/JS + Netlify Functions + Supabase。収益なし、本番稼働
 7. **netlify.toml** の `/result/` リダイレクトは `force=true` 必須。
 8. **windowに露出している関数・変数を消さない。** Chrome拡張（VWP New Tab）が `Object.defineProperty` でwindow変数を監視する。ES Modules化しても外部依存のあるものは `window.xxx = xxx` で露出を維持。
 9. **KAMITSUBAKIガイドライン**: 非商業・UNOFFICIAL明示・公式素材の使用禁止。音楽再生はYouTube別タブ遷移のみ（IFrame埋め込みは採用しない）。
-10. **自動publishは永久にしない。** 自動取り込みは常に `status='pending'` 止まり。公開判断は人間。
+10. **ingest-youtube の自動取り込みは `status='published'` で着地する**（2026-07-14 Yuki決定により改訂）。公開後の品質管理は事後運用: admin で REJECT / 編集可。`rejected` への遷移経路は維持する。**前提条件**: dedup 全件fetchのページングループ（憲法5）が正しく機能していること。dedup が壊れた状態での自動publishは重複が即サイトに出るため、憲法5違反は本条の停止条件になる。手動経路（playlist-import / videos-add / admin）は従来どおり `status='pending'` で人間が公開判断する（自動publishの対象は ingest-youtube のみ）。
 
 ## 設計思想
 

--- a/netlify/functions/ingest-youtube.js
+++ b/netlify/functions/ingest-youtube.js
@@ -2,7 +2,8 @@
 // ingest-youtube.js — YouTube自動取り込みFunction
 // スケジュール: 6時間ごと (netlify.toml で設定)
 // 手動起動: Authorization: Bearer <ADMIN_PASSWORD> が必要
-// 自動publish禁止 — 取り込みは常に status='pending' 止まり
+// 取り込みは status='published' 着地（2026-07-14 Yuki決定・憲法10改訂済み）
+// 前提: dedup全件fetchのページングループ（憲法5）が正しく動作していること
 // ═══════════════════════════════════════════════════════════════
 
 const { getSupabaseUrl, secretKey, sbHeaders: buildSbHeaders, sbFetch, fetchAllVideoRows } = require('./_shared/supabase');
@@ -303,7 +304,7 @@ exports.handler = async (event) => {
             note: '',
             spotify_url: null,
             album_id: null,
-            status: 'pending',        // 自動publishは絶対禁止
+            status: 'published',      // 憲法10改訂: 自動取り込みはpublished着地（2026-07-14 Yuki決定）
             content_type: contentType,
             source: 'youtube_auto',
             ingested_at: new Date().toISOString()
@@ -312,7 +313,7 @@ exports.handler = async (event) => {
           if (publishedAt) resolvedPubs.push(publishedAt);
         }
 
-        // (g) INSERT（status='pending', source='youtube_auto', ingested_at=now()）
+        // (g) INSERT（status='published', source='youtube_auto', ingested_at=now()）
         let inserted = 0;
         if (toInsert.length > 0) {
           const insRes = await fetch(


### PR DESCRIPTION
#126 の作り直し（base ブランチ #125 マージ・削除に伴い自動CLOSEDされたため）。内容・レビュー履歴は #126 を参照。差分は3コミット（憲法10改訂 + ingest published着地 + レビューW1対応）のみ。依存していた PR #125 はマージ済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)