### PR TITLE
feat(albums): 在庫自動スキャン — FINDME STORE(Shopify)を日次同期しis_sold_out自動更新

### DIFF
--- a/.github/workflows/albums-stock-scan.yml
+++ b/.github/workflows/albums-stock-scan.yml
@@ -1,0 +1,43 @@
+# albums-stock-scan 定期起動（GitHub Actions cron）
+#
+# アルバム在庫の自動スキャン: FINDME STORE（Shopify）の product.js `available` を
+# albums.is_sold_out へ日次同期する。ingest-youtube.yml と同じHTTP起動方式。
+#
+# 注意:
+# - schedule はデフォルトブランチ（main）上のworkflowのみ実行される（マージ後に有効化）。
+# - リポジトリが60日間非活動だとGitHubがcronを自動停止する（手動で再有効化が必要）。
+# - Secret `ADMIN_PASSWORD` は ingest-youtube と共用（登録済みならそのまま動く）。
+# - `changed` の中身をechoするので、Actionsログが在庫変更の履歴になる。
+
+name: albums-stock-scan
+
+on:
+  schedule:
+    - cron: '0 21 * * *' # UTC 21:00 = JST 朝6:00、1日1回
+  workflow_dispatch: # 手動実行用
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Invoke albums-stock-scan function
+        run: |
+          set -euo pipefail
+          response=$(curl -sf --max-time 120 -X POST \
+            -H "Authorization: Bearer ${{ secrets.ADMIN_PASSWORD }}" \
+            https://vwp-archive.netlify.app/.netlify/functions/albums-stock-scan)
+          echo "Response: ${response}"
+          ok=$(echo "${response}" | jq -r '.ok')
+          scanned=$(echo "${response}" | jq -r '.scanned')
+          changed_count=$(echo "${response}" | jq -r '.changed | length')
+          skipped_count=$(echo "${response}" | jq -r '.skipped | length')
+          echo "ok=${ok} scanned=${scanned} changed=${changed_count} skipped=${skipped_count}"
+          if [ "${changed_count}" != "0" ] && [ "${changed_count}" != "null" ]; then
+            echo "--- changed（在庫状態が変わったアルバム） ---"
+            echo "${response}" | jq -c '.changed[]'
+          fi
+          if [ "${ok}" != "true" ]; then
+            echo "albums-stock-scan returned ok != true" >&2
+            exit 1
+          fi

--- a/.github/workflows/albums-stock-scan.yml
+++ b/.github/workflows/albums-stock-scan.yml
@@ -26,13 +26,15 @@ jobs:
           set -euo pipefail
           response=$(curl -sf --max-time 120 -X POST \
             -H "Authorization: Bearer ${{ secrets.ADMIN_PASSWORD }}" \
-            https://vwp-archive.netlify.app/.netlify/functions/albums-stock-scan)
+            https://vwp-archive.netlify.app/.netlify/functions/albums-stock-scan) \
+            || { echo "curl failed: ネットワーク断 / Netlify 5xx / Function timeout の可能性（-f はHTTPエラー時に本文を捨てる）" >&2; exit 1; }
           echo "Response: ${response}"
           ok=$(echo "${response}" | jq -r '.ok')
           scanned=$(echo "${response}" | jq -r '.scanned')
           changed_count=$(echo "${response}" | jq -r '.changed | length')
           skipped_count=$(echo "${response}" | jq -r '.skipped | length')
-          echo "ok=${ok} scanned=${scanned} changed=${changed_count} skipped=${skipped_count}"
+          elapsed_ms=$(echo "${response}" | jq -r '.elapsed_ms')
+          echo "ok=${ok} scanned=${scanned} changed=${changed_count} skipped=${skipped_count} elapsed_ms=${elapsed_ms}"
           if [ "${changed_count}" != "0" ] && [ "${changed_count}" != "null" ]; then
             echo "--- changed（在庫状態が変わったアルバム） ---"
             echo "${response}" | jq -c '.changed[]'

--- a/netlify/functions/albums-stock-scan.js
+++ b/netlify/functions/albums-stock-scan.js
@@ -1,0 +1,141 @@
+// ═══════════════════════════════════════════════════════════════
+// albums-stock-scan.js — アルバム在庫自動スキャンFunction
+// 起動: GitHub Actions cron（1日1回 JST朝6:00）+ 手動curl
+//       Authorization: Bearer <ADMIN_PASSWORD> 必須（POSTのみ）
+// 対象: albums.purchase_url が FINDME STORE（findmestore.thinkr.jp = Shopify）の行。
+//       `https://findmestore.thinkr.jp/products/<handle>.js` の JSON `available` を
+//       is_sold_out へ同期する（newSoldOut = !available）。
+// 安全側の原則: HTTPエラー・非JSON・available欠落・ハンドル抽出失敗は該当行を
+//       skipped に記録して is_sold_out には絶対に触らない（ページ消滅・一時障害で
+//       誤って SALE に戻す事故防止）。更新は判定が確定し現状と異なる場合のみ。
+// ═══════════════════════════════════════════════════════════════
+
+const { getSupabaseUrl, secretKey, sbHeaders, sbFetch } = require('./_shared/supabase');
+const { methodNotAllowed, json } = require('./_shared/responses');
+
+// 対応ストアの判定文字列（将来ストア追加時はここに分岐を足す。対象外は skipped:unsupported_domain）
+const SUPPORTED_STORE = 'findmestore.thinkr.jp/products/';
+// purchase_url からの商品ハンドル抽出（例: /products/kyoso?query → kyoso）
+const HANDLE_RE = /\/products\/([^/?#]+)/;
+const FETCH_TIMEOUT_MS = 10000; // Shopify product.js のタイムアウト
+const POLITE_WAIT_MS = 300;     // 逐次リクエスト間の待機（礼儀）
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+exports.handler = async (event) => {
+  if (event.httpMethod !== 'POST') return methodNotAllowed();
+
+  // ── 起動ガード（ingest-youtube の手動起動ガードと同型） ──
+  // 本Functionは常にHTTP起動（GitHub Actions cron / 手動curl）のため無条件で必須。
+  const ADMIN_PW = process.env.ADMIN_PASSWORD;
+  const authHeader = event.headers?.authorization || event.headers?.Authorization || '';
+  const token = authHeader.replace(/^Bearer\s+/i, '').trim();
+  if (!ADMIN_PW || token !== ADMIN_PW) {
+    return json(401, { error: '起動には Authorization: Bearer <ADMIN_PASSWORD> が必要です' });
+  }
+
+  const SUPABASE_URL = getSupabaseUrl();
+  const SUPABASE_KEY = secretKey();
+  if (!SUPABASE_URL || !SUPABASE_KEY) {
+    return json(500, { error: '環境変数が不足しています' });
+  }
+
+  try {
+    // ── albums 全件取得 ──
+    // 現状31件程度なので単発クエリでよいが、憲法5の精神で limit 明示 + order=id.asc。
+    // limit=1000 は PostgREST Max Rows キャップと同値（albumsが1,000件に迫ったらページング化すること）。
+    const albums = await sbFetch(
+      `${SUPABASE_URL}/rest/v1/albums?select=id,name,purchase_url,is_sold_out&order=id.asc&limit=1000`,
+      { headers: sbHeaders(SUPABASE_KEY) },
+      { errSlice: 300 }
+    );
+    if (!Array.isArray(albums)) {
+      return json(500, { error: 'albums取得結果が配列ではありません' });
+    }
+
+    // ── 対象抽出（purchase_url なしは対象外・記録もしない） ──
+    const targets = [];  // { album, handle }
+    const skipped = [];  // { id, reason }
+    for (const album of albums) {
+      const url = album.purchase_url;
+      if (!url) continue;
+      if (!url.includes(SUPPORTED_STORE)) {
+        // 将来ストア追加の目印
+        skipped.push({ id: album.id, reason: 'unsupported_domain' });
+        continue;
+      }
+      const m = HANDLE_RE.exec(url);
+      if (!m) {
+        skipped.push({ id: album.id, reason: 'handle_extract_failed' });
+        continue;
+      }
+      targets.push({ album, handle: m[1] });
+    }
+
+    // ── 逐次スキャン（並列にしない + 300ms待機 = ストアへの礼儀） ──
+    const changed = [];  // { id, name, from, to }
+    let scanned = 0;     // product.js のfetchを試行した件数
+    const today = new Date().toISOString().slice(0, 10); // status_updated_at（YYYY-MM-DD）
+
+    for (let i = 0; i < targets.length; i++) {
+      const { album, handle } = targets[i];
+      if (i > 0) await sleep(POLITE_WAIT_MS);
+      scanned++;
+
+      // (1) Shopify product.js fetch — 失敗系はすべて skip（is_sold_out に触らない）
+      let res;
+      try {
+        res = await fetch(`https://findmestore.thinkr.jp/products/${handle}.js`, {
+          headers: {
+            'User-Agent': 'vwp-archive-stock-scan/1.0 (+https://vwp-archive.netlify.app)',
+            Accept: 'application/json',
+          },
+          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        });
+      } catch (e) {
+        const detail = (e && e.name === 'TimeoutError') ? 'timeout' : String(e && e.message).slice(0, 100);
+        skipped.push({ id: album.id, reason: `fetch_error: ${detail}` });
+        continue;
+      }
+      if (!res.ok) {
+        // 404 = ページ消滅の可能性。売り切れ扱いにせず skip（人間が purchase_url を見直す）
+        skipped.push({ id: album.id, reason: `http_${res.status}` });
+        continue;
+      }
+      let product;
+      try {
+        product = await res.json();
+      } catch {
+        skipped.push({ id: album.id, reason: 'invalid_json' });
+        continue;
+      }
+      // available が boolean 以外（メンテページ等の想定外JSON）は判定不能として skip
+      if (!product || typeof product.available !== 'boolean') {
+        skipped.push({ id: album.id, reason: 'available_not_boolean' });
+        continue;
+      }
+
+      // (2) 判定・差分がある場合のみ更新
+      const newSoldOut = !product.available;
+      if (newSoldOut === album.is_sold_out) continue; // 変化なし
+
+      const patchRes = await fetch(`${SUPABASE_URL}/rest/v1/albums?id=eq.${album.id}`, {
+        method: 'PATCH',
+        headers: sbHeaders(SUPABASE_KEY, { 'Content-Type': 'application/json', Prefer: 'return=minimal' }),
+        body: JSON.stringify({ is_sold_out: newSoldOut, status_updated_at: today }),
+      });
+      if (!patchRes.ok) {
+        const text = await patchRes.text().catch(() => '');
+        console.error(`albums-stock-scan: PATCH失敗 id=${album.id}: ${patchRes.status} ${text.slice(0, 200)}`);
+        skipped.push({ id: album.id, reason: `patch_failed_${patchRes.status}` });
+        continue;
+      }
+      changed.push({ id: album.id, name: album.name, from: album.is_sold_out, to: newSoldOut });
+    }
+
+    return json(200, { ok: true, scanned, changed, skipped });
+  } catch (e) {
+    console.error('albums-stock-scan fatal error:', e);
+    return json(500, { error: e.message });
+  }
+};

--- a/netlify/functions/albums-stock-scan.js
+++ b/netlify/functions/albums-stock-scan.js
@@ -5,22 +5,79 @@
 // 対象: albums.purchase_url が FINDME STORE（findmestore.thinkr.jp = Shopify）の行。
 //       `https://findmestore.thinkr.jp/products/<handle>.js` の JSON `available` を
 //       is_sold_out へ同期する（newSoldOut = !available）。
-// 安全側の原則: HTTPエラー・非JSON・available欠落・ハンドル抽出失敗は該当行を
+// 安全側の原則: HTTPエラー・非JSON・available欠落・URL/ハンドル不正は該当行を
 //       skipped に記録して is_sold_out には絶対に触らない（ページ消滅・一時障害で
 //       誤って SALE に戻す事故防止）。更新は判定が確定し現状と異なる場合のみ。
+// 時間予算: Netlify Functionsの10秒制限内に収めるため同時5件のバッチ並列 +
+//       全体8秒デッドライン（超過分は skipped:deadline で部分結果応答 → 翌日cronが拾う）。
 // ═══════════════════════════════════════════════════════════════
 
 const { getSupabaseUrl, secretKey, sbHeaders, sbFetch } = require('./_shared/supabase');
 const { methodNotAllowed, json } = require('./_shared/responses');
 
-// 対応ストアの判定文字列（将来ストア追加時はここに分岐を足す。対象外は skipped:unsupported_domain）
-const SUPPORTED_STORE = 'findmestore.thinkr.jp/products/';
-// purchase_url からの商品ハンドル抽出（例: /products/kyoso?query → kyoso）
+// 対応ストア（将来ストア追加時はここに分岐を足す。対象外は skipped:unsupported_domain）
+const SUPPORTED_HOST = 'findmestore.thinkr.jp';
+const SUPPORTED_PATH_PREFIX = '/products/';
+// pathname からの商品ハンドル抽出（例: /products/kyoso → kyoso）
 const HANDLE_RE = /\/products\/([^/?#]+)/;
-const FETCH_TIMEOUT_MS = 10000; // Shopify product.js のタイムアウト
-const POLITE_WAIT_MS = 300;     // 逐次リクエスト間の待機（礼儀）
+const FETCH_TIMEOUT_MS = 5000;  // Shopify product.js の個別タイムアウト
+const BATCH_SIZE = 5;           // 同時fetch数（ストアへの礼儀と時間予算のバランス）
+const BATCH_WAIT_MS = 100;      // バッチ間の待機
+const DEADLINE_MS = 8000;       // 全体デッドライン（Netlify 10秒制限に対する余裕）
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * 1アルバムのスキャン: product.js fetch → 判定 → 差分があればPATCH。
+ * 戻り値: { skip: reason } | { change: {id,name,from,to} } | {}（変化なし）
+ * throwしない設計（失敗系はすべて skip として返す）。
+ */
+async function scanOne({ album, handle }, supabaseUrl, supabaseKey, today) {
+  // (1) Shopify product.js fetch — 失敗系はすべて skip（is_sold_out に触らない）
+  let res;
+  try {
+    res = await fetch(`https://${SUPPORTED_HOST}/products/${handle}.js`, {
+      headers: {
+        'User-Agent': 'vwp-archive-stock-scan/1.0 (+https://vwp-archive.netlify.app)',
+        Accept: 'application/json',
+      },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+  } catch (e) {
+    const detail = (e && e.name === 'TimeoutError') ? 'timeout' : String(e && e.message).slice(0, 100);
+    return { skip: `fetch_error: ${detail}` };
+  }
+  if (!res.ok) {
+    // 404 = ページ消滅の可能性。売り切れ扱いにせず skip（人間が purchase_url を見直す）
+    return { skip: `http_${res.status}` };
+  }
+  let product;
+  try {
+    product = await res.json();
+  } catch {
+    return { skip: 'invalid_json' };
+  }
+  // available が boolean 以外（メンテページ等の想定外JSON）は判定不能として skip
+  if (!product || typeof product.available !== 'boolean') {
+    return { skip: 'available_not_boolean' };
+  }
+
+  // (2) 判定・差分がある場合のみ更新
+  const newSoldOut = !product.available;
+  if (newSoldOut === album.is_sold_out) return {}; // 変化なし
+
+  const patchRes = await fetch(`${supabaseUrl}/rest/v1/albums?id=eq.${album.id}`, {
+    method: 'PATCH',
+    headers: sbHeaders(supabaseKey, { 'Content-Type': 'application/json', Prefer: 'return=minimal' }),
+    body: JSON.stringify({ is_sold_out: newSoldOut, status_updated_at: today }),
+  });
+  if (!patchRes.ok) {
+    const text = await patchRes.text().catch(() => '');
+    console.error(`albums-stock-scan: PATCH失敗 id=${album.id}: ${patchRes.status} ${text.slice(0, 200)}`);
+    return { skip: `patch_failed_${patchRes.status}` };
+  }
+  return { change: { id: album.id, name: album.name, from: album.is_sold_out, to: newSoldOut } };
+}
 
 exports.handler = async (event) => {
   if (event.httpMethod !== 'POST') return methodNotAllowed();
@@ -40,6 +97,8 @@ exports.handler = async (event) => {
     return json(500, { error: '環境変数が不足しています' });
   }
 
+  const startedAt = Date.now();
+
   try {
     // ── albums 全件取得 ──
     // 現状31件程度なので単発クエリでよいが、憲法5の精神で limit 明示 + order=id.asc。
@@ -54,17 +113,26 @@ exports.handler = async (event) => {
     }
 
     // ── 対象抽出（purchase_url なしは対象外・記録もしない） ──
+    // ドメイン判定は new URL() のパース結果で厳格に行う（部分文字列判定だと
+    // https://evil.com/findmestore.thinkr.jp/products/x のようなURLを通してしまう）。
     const targets = [];  // { album, handle }
     const skipped = [];  // { id, reason }
     for (const album of albums) {
       const url = album.purchase_url;
       if (!url) continue;
-      if (!url.includes(SUPPORTED_STORE)) {
+      let parsed;
+      try {
+        parsed = new URL(url);
+      } catch {
+        skipped.push({ id: album.id, reason: 'invalid_url' });
+        continue;
+      }
+      if (parsed.hostname !== SUPPORTED_HOST || !parsed.pathname.startsWith(SUPPORTED_PATH_PREFIX)) {
         // 将来ストア追加の目印
         skipped.push({ id: album.id, reason: 'unsupported_domain' });
         continue;
       }
-      const m = HANDLE_RE.exec(url);
+      const m = HANDLE_RE.exec(parsed.pathname);
       if (!m) {
         skipped.push({ id: album.id, reason: 'handle_extract_failed' });
         continue;
@@ -72,68 +140,37 @@ exports.handler = async (event) => {
       targets.push({ album, handle: m[1] });
     }
 
-    // ── 逐次スキャン（並列にしない + 300ms待機 = ストアへの礼儀） ──
+    // ── バッチ並列スキャン（同時5件 + バッチ間100ms + 全体8秒デッドライン） ──
     const changed = [];  // { id, name, from, to }
     let scanned = 0;     // product.js のfetchを試行した件数
     const today = new Date().toISOString().slice(0, 10); // status_updated_at（YYYY-MM-DD）
 
-    for (let i = 0; i < targets.length; i++) {
-      const { album, handle } = targets[i];
-      if (i > 0) await sleep(POLITE_WAIT_MS);
-      scanned++;
-
-      // (1) Shopify product.js fetch — 失敗系はすべて skip（is_sold_out に触らない）
-      let res;
-      try {
-        res = await fetch(`https://findmestore.thinkr.jp/products/${handle}.js`, {
-          headers: {
-            'User-Agent': 'vwp-archive-stock-scan/1.0 (+https://vwp-archive.netlify.app)',
-            Accept: 'application/json',
-          },
-          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-        });
-      } catch (e) {
-        const detail = (e && e.name === 'TimeoutError') ? 'timeout' : String(e && e.message).slice(0, 100);
-        skipped.push({ id: album.id, reason: `fetch_error: ${detail}` });
-        continue;
+    for (let i = 0; i < targets.length; i += BATCH_SIZE) {
+      // デッドライン超過: 残りはスキャンせず skipped:deadline で部分結果応答（翌日cronが拾う）
+      if (Date.now() - startedAt >= DEADLINE_MS) {
+        for (const t of targets.slice(i)) skipped.push({ id: t.album.id, reason: 'deadline' });
+        break;
       }
-      if (!res.ok) {
-        // 404 = ページ消滅の可能性。売り切れ扱いにせず skip（人間が purchase_url を見直す）
-        skipped.push({ id: album.id, reason: `http_${res.status}` });
-        continue;
+      if (i > 0) await sleep(BATCH_WAIT_MS);
+      const batch = targets.slice(i, i + BATCH_SIZE);
+      const settled = await Promise.allSettled(
+        batch.map((t) => scanOne(t, SUPABASE_URL, SUPABASE_KEY, today))
+      );
+      // 集計はバッチ内のtargets順（並列の完了順に依存しない安定した応答順）
+      for (let j = 0; j < settled.length; j++) {
+        scanned++;
+        const s = settled[j];
+        if (s.status !== 'fulfilled') {
+          // scanOneはthrowしない設計だが、万一の想定外例外もis_sold_outに触らずskip
+          skipped.push({ id: batch[j].album.id, reason: `scan_error: ${String(s.reason && s.reason.message).slice(0, 100)}` });
+          continue;
+        }
+        if (s.value.skip) skipped.push({ id: batch[j].album.id, reason: s.value.skip });
+        else if (s.value.change) changed.push(s.value.change);
       }
-      let product;
-      try {
-        product = await res.json();
-      } catch {
-        skipped.push({ id: album.id, reason: 'invalid_json' });
-        continue;
-      }
-      // available が boolean 以外（メンテページ等の想定外JSON）は判定不能として skip
-      if (!product || typeof product.available !== 'boolean') {
-        skipped.push({ id: album.id, reason: 'available_not_boolean' });
-        continue;
-      }
-
-      // (2) 判定・差分がある場合のみ更新
-      const newSoldOut = !product.available;
-      if (newSoldOut === album.is_sold_out) continue; // 変化なし
-
-      const patchRes = await fetch(`${SUPABASE_URL}/rest/v1/albums?id=eq.${album.id}`, {
-        method: 'PATCH',
-        headers: sbHeaders(SUPABASE_KEY, { 'Content-Type': 'application/json', Prefer: 'return=minimal' }),
-        body: JSON.stringify({ is_sold_out: newSoldOut, status_updated_at: today }),
-      });
-      if (!patchRes.ok) {
-        const text = await patchRes.text().catch(() => '');
-        console.error(`albums-stock-scan: PATCH失敗 id=${album.id}: ${patchRes.status} ${text.slice(0, 200)}`);
-        skipped.push({ id: album.id, reason: `patch_failed_${patchRes.status}` });
-        continue;
-      }
-      changed.push({ id: album.id, name: album.name, from: album.is_sold_out, to: newSoldOut });
     }
 
-    return json(200, { ok: true, scanned, changed, skipped });
+    return json(200, { ok: true, scanned, changed, skipped, elapsed_ms: Date.now() - startedAt });
   } catch (e) {
     console.error('albums-stock-scan fatal error:', e);
     return json(500, { error: e.message });

--- a/tests/fn-snapshot/scenarios.mjs
+++ b/tests/fn-snapshot/scenarios.mjs
@@ -962,11 +962,15 @@ scenarios.push(
     event: post({}, { authorization: `Bearer ${PW}` }), routes: [],
   },
   {
-    // 在庫変化あり/なし + 対象外ドメイン + purchase_urlなし + ハンドル抽出失敗の混在。
+    // 在庫変化あり/なし + 対象外ドメイン + purchase_urlなし + URL/ハンドル不正の混在。
     // id1: SALE→SOLD OUT / id2: SOLD OUT→SALE（両方PATCH。status_updated_at=固定日 2026-01-15）
     // id3: available=true & is_sold_out=false → 変化なし（PATCHなし）
     // id4: 対象外ドメイン → skipped:unsupported_domain / id5: purchase_urlなし → 記録なし
     // id6: /products/ 直後にハンドルなし → skipped:handle_extract_failed
+    // id7: pathに正規ドメインを埋めた偽URL → hostname厳格判定で unsupported_domain
+    // id8: URLとしてパース不能 → skipped:invalid_url
+    // ※対象3件は1バッチ（同時5件以内）で並列実行。スタブfetchは同期解決のため
+    //   calls順（fetch発行順→microtask解決順）は決定論的。集計はtargets順なので応答も安定。
     name: 'albums-stock-scan/scan-mixed', fn: 'albums-stock-scan',
     event: post({}, { authorization: `Bearer ${PW}` }),
     routes: [
@@ -977,6 +981,8 @@ scenarios.push(
         { id: 4, name: '外部ストア盤', purchase_url: 'https://example.com/shop/x', is_sold_out: false },
         { id: 5, name: 'URLなし盤', purchase_url: null, is_sold_out: true },
         { id: 6, name: '壊れURL盤', purchase_url: `${FM}?query`, is_sold_out: false },
+        { id: 7, name: '偽装URL盤', purchase_url: 'https://evil.com/findmestore.thinkr.jp/products/x', is_sold_out: false },
+        { id: 8, name: 'パース不能盤', purchase_url: 'not a url', is_sold_out: false },
       ]),
       shopifyRoute('album-a', { id: 111, title: '狂想', available: false }),
       shopifyRoute('album-b', { id: 222, title: '不可解', available: true }),

--- a/tests/fn-snapshot/scenarios.mjs
+++ b/tests/fn-snapshot/scenarios.mjs
@@ -939,3 +939,83 @@ scenarios.push(
     routes: [{ match: 'youtube/v3/videos', networkError: 'network down dummy' }],
   },
 );
+
+// ═══════════════════════════════════════════════════════════════
+// albums-stock-scan（FINDME STORE在庫スキャン）
+// ═══════════════════════════════════════════════════════════════
+const FM = 'https://findmestore.thinkr.jp/products/';
+// albums一覧fetch（select=id,name,purchase_url,is_sold_out&order=id.asc&limit=1000）
+const stockAlbumsRoute = (rows) => ({
+  method: 'GET', match: 'albums?select=id,name,purchase_url,is_sold_out', body: rows,
+});
+// Shopify product.js fixture
+const shopifyRoute = (handle, body, opts = {}) => ({
+  method: 'GET', match: `findmestore.thinkr.jp/products/${handle}.js`, ...opts, body,
+});
+
+scenarios.push(
+  { name: 'albums-stock-scan/405-get', fn: 'albums-stock-scan', event: get(), routes: [] },
+  { name: 'albums-stock-scan/no-auth', fn: 'albums-stock-scan', event: post({}), routes: [] },
+  { name: 'albums-stock-scan/auth-fail', fn: 'albums-stock-scan', event: post({}, { authorization: 'Bearer wrong_pw' }), routes: [] },
+  {
+    name: 'albums-stock-scan/env-missing', fn: 'albums-stock-scan', env: { SUPABASE_URL: undefined },
+    event: post({}, { authorization: `Bearer ${PW}` }), routes: [],
+  },
+  {
+    // 在庫変化あり/なし + 対象外ドメイン + purchase_urlなし + ハンドル抽出失敗の混在。
+    // id1: SALE→SOLD OUT / id2: SOLD OUT→SALE（両方PATCH。status_updated_at=固定日 2026-01-15）
+    // id3: available=true & is_sold_out=false → 変化なし（PATCHなし）
+    // id4: 対象外ドメイン → skipped:unsupported_domain / id5: purchase_urlなし → 記録なし
+    // id6: /products/ 直後にハンドルなし → skipped:handle_extract_failed
+    name: 'albums-stock-scan/scan-mixed', fn: 'albums-stock-scan',
+    event: post({}, { authorization: `Bearer ${PW}` }),
+    routes: [
+      stockAlbumsRoute([
+        { id: 1, name: '狂想', purchase_url: `${FM}album-a?query`, is_sold_out: false },
+        { id: 2, name: '不可解', purchase_url: `${FM}album-b?query`, is_sold_out: true },
+        { id: 3, name: '観測', purchase_url: `${FM}album-c`, is_sold_out: false },
+        { id: 4, name: '外部ストア盤', purchase_url: 'https://example.com/shop/x', is_sold_out: false },
+        { id: 5, name: 'URLなし盤', purchase_url: null, is_sold_out: true },
+        { id: 6, name: '壊れURL盤', purchase_url: `${FM}?query`, is_sold_out: false },
+      ]),
+      shopifyRoute('album-a', { id: 111, title: '狂想', available: false }),
+      shopifyRoute('album-b', { id: 222, title: '不可解', available: true }),
+      shopifyRoute('album-c', { id: 333, title: '観測', available: true }),
+      { method: 'PATCH', match: 'albums?id=eq.1', status: 204, body: '' },
+      { method: 'PATCH', match: 'albums?id=eq.2', status: 204, body: '' },
+    ],
+  },
+  {
+    // fetch失敗系の網羅: HTTP404 / 非JSON / ネットワークエラー / available欠落 — すべてskipで
+    // is_sold_out不変（PATCHが1本も飛ばないことをcallsで保証）。誤SALE戻し事故防止の核心。
+    name: 'albums-stock-scan/scan-skip-errors', fn: 'albums-stock-scan',
+    event: post({}, { authorization: `Bearer ${PW}` }),
+    routes: [
+      stockAlbumsRoute([
+        { id: 11, name: '消滅ページ盤', purchase_url: `${FM}gone`, is_sold_out: false },
+        { id: 12, name: '非JSON盤', purchase_url: `${FM}broken`, is_sold_out: false },
+        { id: 13, name: '通信断盤', purchase_url: `${FM}netdown`, is_sold_out: true },
+        { id: 14, name: 'available欠落盤', purchase_url: `${FM}weird`, is_sold_out: false },
+      ]),
+      shopifyRoute('gone', 'Not Found', { status: 404 }),
+      shopifyRoute('broken', '<!doctype html>not json'),
+      shopifyRoute('netdown', null, { networkError: 'network down dummy' }),
+      shopifyRoute('weird', { id: 444, title: 'available欠落盤' }),
+    ],
+  },
+  {
+    name: 'albums-stock-scan/albums-sb-error', fn: 'albums-stock-scan',
+    event: post({}, { authorization: `Bearer ${PW}` }),
+    routes: [{ method: 'GET', match: 'albums?select=id,name,purchase_url,is_sold_out', status: 500, body: 'E'.repeat(350) }],
+  },
+  {
+    // PATCH失敗はchangedに入れずskipped（patch_failed_500）へ
+    name: 'albums-stock-scan/patch-fail', fn: 'albums-stock-scan',
+    event: post({}, { authorization: `Bearer ${PW}` }),
+    routes: [
+      stockAlbumsRoute([{ id: 21, name: 'PATCH失敗盤', purchase_url: `${FM}album-x`, is_sold_out: false }]),
+      shopifyRoute('album-x', { id: 555, title: 'PATCH失敗盤', available: false }),
+      { method: 'PATCH', match: 'albums?id=eq.21', status: 500, body: 'db down' },
+    ],
+  },
+);


### PR DESCRIPTION
## 目的

アルバムの SALE / SOLD OUT を手動更新しており見逃しが多い（Yuki報告）。販売サイトを1日1回自動スキャンし `albums.is_sold_out` を実在庫に同期する。

## 変更したもの（追加のみ・既存コード変更ゼロ）

- `netlify/functions/albums-stock-scan.js`（新規）: albums の purchase_url（31件、全て findmestore.thinkr.jp = Shopify）からハンドルを抽出し、Shopify 公式 JSON `/products/<handle>.js` の `available` を照会。`is_sold_out` と差分がある行のみ PATCH（`status_updated_at` も当日で更新）
  - HTMLスクレイピング不使用（Shopify公式エンドポイント、実測済み）
  - 同時5件バッチ並列 + 全体8秒デッドライン（Netlify 10秒制限対策。超過分は skipped で翌日回収）
  - **エラー時は絶対に is_sold_out を触らない**: 404/タイムアウト/非JSON/available非boolean/URLパース不能 → すべて skipped 記録のみ（ページ消滅品を誤って SALE に戻す事故防止）
  - ドメイン検証は `new URL()` の hostname 完全一致（substring偽装 `evil.com/findmestore...` を遮断）
  - 認証: `Bearer ADMIN_PASSWORD`（ingest-youtube と同形）
- `.github/workflows/albums-stock-scan.yml`（新規): cron `0 21 * * *`（JST 朝6:00）+ workflow_dispatch。`changed` の中身を echo するので Actions ログが在庫変更履歴になる。Secret は既存 `ADMIN_PASSWORD` 共用（追加設定不要）
- `tests/fn-snapshot/scenarios.mjs`: 8シナリオ追加（認証・在庫変化両方向・偽装URL・404/非JSON/通信断で PATCH 0本の保証・PATCH失敗）

## 変更していないもの（保証事項)

- videos テーブル・publish系ロジック不接触（新シナリオの calls に /videos への外向きリクエスト0件を機械確認）
- 既存 Function・フロント・admin 変更ゼロ
- 既存 fn-snapshot 156シナリオ base比バイト一致。合計164シナリオ、2回実行 diff 空（決定論性確認）
- admin での手動 SOLD OUT 変更は引き続き可能（ただしストア実態と食い違えば翌日のスキャンが上書き = ストアが正）

## レビュー往復履歴（reviewerの指摘と対応）

1往復:
- **BUG**: 逐次+300ms待機×31件で Netlify 10秒制限超過 → バッチ並列5+個別5秒タイムアウト+全体8秒デッドラインに再設計（実測見積もり 2.7〜3.5秒）
- **RISK**: ドメイン判定が substring で偽装可能 → URL パース + hostname 完全一致に厳格化（偽装URL fixture で機械検証）
- **NIT**: workflow の curl 失敗時に原因不明 → 失敗メッセージ追加

## 動作確認方法（Yuki向け手順）

1. マージ後、Actions → albums-stock-scan → Run workflow（手動実行）
2. ログの Response に `ok:true, scanned:31, changed:[...]` — changed に出た行が実在庫と手動登録のズレ（初回はまとめて補正される見込み）
3. サイトのアルバム棚で SOLD OUT バッジが実在庫と一致すること
4. 翌朝6時以降、Actions に cron 実行が並ぶこと

## 判断保留リスト

- `scanned` は fetch 試行件数（deadline スキップ分は含まず)
- deadline 経路は fn-snapshot ハーネスの制約（Date.now 固定）で自動テスト不能。コードレビューでの担保
- 404 が恒久化した商品（ストアからページ削除）は毎日 skipped に載るだけで通知なし。必要なら後続で閾値アラート

🤖 Generated with [Claude Code](https://claude.com/claude-code)