### PR TITLE
fix(albums-scan): /collections/.../products/ 形式のURLからもハンドル抽出（31件全カバー）

### DIFF
--- a/netlify/functions/albums-stock-scan.js
+++ b/netlify/functions/albums-stock-scan.js
@@ -17,8 +17,7 @@ const { methodNotAllowed, json } = require('./_shared/responses');
 
 // 対応ストア（将来ストア追加時はここに分岐を足す。対象外は skipped:unsupported_domain）
 const SUPPORTED_HOST = 'findmestore.thinkr.jp';
-const SUPPORTED_PATH_PREFIX = '/products/';
-// pathname からの商品ハンドル抽出（例: /products/kyoso → kyoso）
+// pathname からの商品ハンドル抽出（例: /products/kyoso, /collections/rim/products/kyoso → kyoso）
 const HANDLE_RE = /\/products\/([^/?#]+)/;
 const FETCH_TIMEOUT_MS = 5000;  // Shopify product.js の個別タイムアウト
 const BATCH_SIZE = 5;           // 同時fetch数（ストアへの礼儀と時間予算のバランス）
@@ -127,14 +126,14 @@ exports.handler = async (event) => {
         skipped.push({ id: album.id, reason: 'invalid_url' });
         continue;
       }
-      if (parsed.hostname !== SUPPORTED_HOST || !parsed.pathname.startsWith(SUPPORTED_PATH_PREFIX)) {
+      if (parsed.hostname !== SUPPORTED_HOST) {
         // 将来ストア追加の目印
         skipped.push({ id: album.id, reason: 'unsupported_domain' });
         continue;
       }
       const m = HANDLE_RE.exec(parsed.pathname);
       if (!m) {
-        skipped.push({ id: album.id, reason: 'handle_extract_failed' });
+        skipped.push({ id: album.id, reason: 'no_products_path' });
         continue;
       }
       targets.push({ album, handle: m[1] });

--- a/tests/fn-snapshot/scenarios.mjs
+++ b/tests/fn-snapshot/scenarios.mjs
@@ -966,10 +966,11 @@ scenarios.push(
     // id1: SALE→SOLD OUT / id2: SOLD OUT→SALE（両方PATCH。status_updated_at=固定日 2026-01-15）
     // id3: available=true & is_sold_out=false → 変化なし（PATCHなし）
     // id4: 対象外ドメイン → skipped:unsupported_domain / id5: purchase_urlなし → 記録なし
-    // id6: /products/ 直後にハンドルなし → skipped:handle_extract_failed
+    // id6: /products/ 直後にハンドルなし → skipped:no_products_path
     // id7: pathに正規ドメインを埋めた偽URL → hostname厳格判定で unsupported_domain
     // id8: URLとしてパース不能 → skipped:invalid_url
-    // ※対象3件は1バッチ（同時5件以内）で並列実行。スタブfetchは同期解決のため
+    // id9: /collections/<c>/products/<handle> 形式 → 正常スキャン（SALE→SOLD OUT）
+    // ※対象4件は1バッチ（同時5件以内）で並列実行。スタブfetchは同期解決のため
     //   calls順（fetch発行順→microtask解決順）は決定論的。集計はtargets順なので応答も安定。
     name: 'albums-stock-scan/scan-mixed', fn: 'albums-stock-scan',
     event: post({}, { authorization: `Bearer ${PW}` }),
@@ -983,12 +984,15 @@ scenarios.push(
         { id: 6, name: '壊れURL盤', purchase_url: `${FM}?query`, is_sold_out: false },
         { id: 7, name: '偽装URL盤', purchase_url: 'https://evil.com/findmestore.thinkr.jp/products/x', is_sold_out: false },
         { id: 8, name: 'パース不能盤', purchase_url: 'not a url', is_sold_out: false },
+        { id: 9, name: 'コレクション経由盤', purchase_url: 'https://findmestore.thinkr.jp/collections/kaf/products/test-handle-1', is_sold_out: false },
       ]),
       shopifyRoute('album-a', { id: 111, title: '狂想', available: false }),
       shopifyRoute('album-b', { id: 222, title: '不可解', available: true }),
       shopifyRoute('album-c', { id: 333, title: '観測', available: true }),
+      shopifyRoute('test-handle-1', { id: 999, title: 'コレクション経由盤', available: false }),
       { method: 'PATCH', match: 'albums?id=eq.1', status: 204, body: '' },
       { method: 'PATCH', match: 'albums?id=eq.2', status: 204, body: '' },
+      { method: 'PATCH', match: 'albums?id=eq.9', status: 204, body: '' },
     ],
   },
   {


### PR DESCRIPTION
## 目的

PR #129 の初回スキャンで、31件中2件（魔法α・NEW ROMANCER）が Shopify のコレクション経由URL（`/collections/<member>/products/<handle>`）のためスキャン対象外になっていた。パス形式に関わらずハンドル抽出できるよう修正し全件カバーする。

## 変更したもの

- `albums-stock-scan.js`: hostname 完全一致チェックは維持し、パス検証を「pathname 内の `/products/<handle>` 抽出regex」に変更。抽出失敗は `no_products_path` としてスキップ（従来通り is_sold_out 不変）。コレクション経由の `.js` エンドポイントが同一JSONを返すことは実測確認済み
- `scenarios.mjs`: collections形式URLの正常スキャン fixture 追加。hostname偽装（evil.com）が `unsupported_domain` で弾かれる fixture は維持

## 変更していないもの（保証事項）

- エラー時に is_sold_out を触らない設計・認証・並列/デッドライン制御は不変
- fn-snapshot 164シナリオ完走確認済み

## 動作確認方法（Yuki向け手順）

マージ後 Actions → albums-stock-scan → Run workflow。`scanned: 31`（前回29）になり、NEW ROMANCER が SOLD OUT → SALE に補正されること（実在庫 available=true 実測済み）。

## 判断保留リスト

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)