### PR TITLE
chore(db): RLS有効化migrationの記録（Supabaseセキュリティ警告対応・適用済み）

### DIFF
--- a/supabase/migrations/20260715000000_enable_rls_ingest_channels.sql
+++ b/supabase/migrations/20260715000000_enable_rls_ingest_channels.sql
@@ -1,0 +1,8 @@
+-- Security advisor対応 (2026-07-15) — 適用済み（apply_migration: enable_rls_ingest_channels_and_fix_search_path）
+-- 1) ingest_channels: RLS有効化（ポリシー無し = anon/authenticated 全拒否）
+--    Netlify Functions は service role key 使用のため RLS を透過、動作影響なし
+ALTER TABLE public.ingest_channels ENABLE ROW LEVEL SECURITY;
+
+-- 2) prevent_fallback_status_change: search_path 固定（WARN: function_search_path_mutable）
+--    関数本体は NEW/OLD のみ参照でテーブル参照なし。ロジック不変（憲法6遵守）
+ALTER FUNCTION public.prevent_fallback_status_change() SET search_path = '';


### PR DESCRIPTION
## 目的
Supabase security advisor の Critical（ingest_channels RLS無効）+ WARN（trigger関数 search_path可変）対応。**DBには apply_migration で適用済み・advisor解消確認済み**。本PRはリポジトリへの記録（憲法: DDLはmigrationファイルで）。

## 変更したもの
- supabase/migrations/20260715000000_enable_rls_ingest_channels.sql（記録のみ、再適用不要）

## 変更していないもの（保証事項）
- guard_waiting_pool / prevent_fallback_status_change のロジック不変（search_path属性のみ、憲法6遵守）
- ingest 実動作確認済み（RLS有効化後 ok:true, processed:5 — service role は RLS 透過）

## 動作確認方法（Yuki向け手順）
Supabase ダッシュボード → Advisors → Security で ERROR/WARN が消えていること（INFO「RLS enabled no policy」は意図通りで残る）

## 判断保留リスト
なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)