### PR TITLE
feat(ingest): Music ArchiveタイトルをShorts分類に追加

### DIFF
--- a/netlify/functions/ingest-youtube.js
+++ b/netlify/functions/ingest-youtube.js
@@ -13,6 +13,8 @@ const { ytId } = require('./_shared/yt');
 
 // ── キーワード定数辞書 ──
 const SHORTS_KEYWORDS = ['#shorts'];
+// 「Music Archive」シリーズはタイトルで判定（description誤爆リスクあり）
+const MUSIC_ARCHIVE_KEYWORDS = ['music archive'];
 const LIVE_KEYWORDS = [
   'ワンマン', 'ライブ映像', '不可解', '現象', '狂想'
 ];
@@ -53,10 +55,11 @@ function classifyContentType(title, description, durationSec, hasLiveDetails) {
   const text = (title + ' ' + (description || '')).toLowerCase();
   const titleLower = title.toLowerCase();
 
-  // shorts: 60秒以下 OR タイトル/descriptionに #shorts
+  // shorts: 60秒以下 OR タイトル/descriptionに #shorts OR タイトルにMusic Archiveキーワード
   if (
     (durationSec !== null && durationSec <= 60) ||
-    SHORTS_KEYWORDS.some(k => text.includes(k.toLowerCase()))
+    SHORTS_KEYWORDS.some(k => text.includes(k.toLowerCase())) ||
+    MUSIC_ARCHIVE_KEYWORDS.some(k => titleLower.includes(k))
   ) {
     return 'shorts';
   }


### PR DESCRIPTION
## 目的
KAMITSUBAKIの「Music Archive」シリーズ（縦型ショート系音源動画）が自動取り込みで `content_type='song'` に分類され、メインMV棚に混ざる問題の解消。タイトルに「Music Archive」（case-insensitive）を含む動画を `content_type='shorts'` に分類する。

きっかけ: 8/2公開の「【Music Archive】#シリウスの心臓 #ヰ世界情緒」がsong着地し手動削除された件（Yuki判断: Music ArchiveはShorts行きでよい）。

## 変更したもの
- `netlify/functions/ingest-youtube.js` のみ（+5 / -2）
  - `MUSIC_ARCHIVE_KEYWORDS = ['music archive']` 定数追加
  - `classifyContentType` のshorts判定に「タイトルに Music Archive を含む」条件をORで追加。**タイトルのみ判定**（descriptionは見ない＝誤爆防止）

## 変更していないもの（保証事項）
- status='published' 着地ロジック（憲法10）・dedup全件fetchページングループ（憲法5）・カーソル制御は無傷（verifierがdiff全行で確認）
- live / announcement / song 判定、既存の #shorts・60秒判定は無改変
- DB遡及なし: 既存レコードに「Music Archive」該当0件（SQL確認済み）
- fn-snapshotテスト164シナリオ: origin/mainとの比較でdiff完全一致（挙動変化ゼロ）

## レビュー往復履歴（reviewerの指摘と対応）
- CRITICAL / MAJOR: なし → 差し戻しゼロ、一発APPROVE
- INFO: 「music archive」部分一致でフル尺MVが誤爆する理論リスク → 誤爆してもメインMV棚には出ず（core.jsのNON_SONG_TYPES除外）shortsカテゴリ格納、adminで1クリック再分類可能なため受容。durationとのAND化はシリーズ名タグ付けの意図を損なうため不採用

## 動作確認方法（Yuki向け手順）
1. マージ＆デプロイ後、次のGitHub Actions cron実行（6時間毎）を待つか、`ingest-youtube` を手動トリガー（Authorization: Bearer ADMIN_PASSWORD）
2. 次に「Music Archive」タイトルの動画が公開されたら、admin または admin-query で `content_type='shorts'` かつ `status='published'` で着地していることを確認
3. 公開サイトのメインMV棚に出ていないこと（shortsカテゴリに入っていること）を目視確認
4. 通常MV・ライブ映像がshortsに化けていないことを確認

## 判断保留リスト
- 削除済み「シリウスの心臓」(元id 1669) はカーソル通過済みのため自動再取り込みされない。shortsとして載せたい場合はadminから手動追加が必要（URL: https://www.youtube.com/watch?v=F77NvkdVaa4）

🤖 Generated with [Claude Code](https://claude.com/claude-code)